### PR TITLE
Make plugin target build without juce headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,6 @@ target_link_libraries("${PROJECT_NAME}"
     juce::juce_recommended_lto_flags
     juce::juce_recommended_warning_flags)
 
-juce_generate_juce_header("${PROJECT_NAME}")
 
 # Required for ctest (which is just easier for cross-platform CI)
 # include(CTest) does this too, but adds tons of targets we don't want

--- a/Source/GUI/Panels/ValentineCenterPanel.cpp
+++ b/Source/GUI/Panels/ValentineCenterPanel.cpp
@@ -8,13 +8,15 @@
   ==============================================================================
 */
 
-#include <JuceHeader.h>
-
 #include "ValentineCenterPanel.h"
 #include "PluginProcessor.h"
 #include "ValentineParameters.h"
+#include "BinaryData.h"
 
 #include "Common/GUI/Utilities/GraphicsUtilities.h"
+#include "Common/GUI/LookAndFeel/LookAndFeel.h"
+
+#include <juce_gui_basics/juce_gui_basics.h>
 
 //==============================================================================
 
@@ -43,19 +45,19 @@ CenterPanel::CenterPanel(ValentineAudioProcessor& processor) :
     addAndMakeVisible(outputSlider);
 
     // Logo
-    vLogo = Drawable::createFromImageData(BinaryData::logo_218x40_svg,
+    vLogo = juce::Drawable::createFromImageData(BinaryData::logo_218x40_svg,
                                           BinaryData::logo_218x40_svgSize); 
     addAndMakeVisible(vLogo.get());
 
     // Version label
-    versionLabel.setText(JucePlugin_VersionString, dontSendNotification);
+    versionLabel.setText(JucePlugin_VersionString, juce::dontSendNotification);
     versionLabel.setColour(juce::Label::ColourIds::textColourId,
                            tote_bag::laf_constants::vPinkDark);
-    versionLabel.setJustificationType(Justification::centredTop);
+    versionLabel.setJustificationType(juce::Justification::centredTop);
     addAndMakeVisible(versionLabel);
 
     // Ratio box
-    if (auto ratioParam = dynamic_cast<AudioParameterChoice*>(processor.treeState.getParameter(FFCompParameterID()[getParameterIndex(VParameter::ratio)])))
+    if (auto ratioParam = dynamic_cast<juce::AudioParameterChoice*>(processor.treeState.getParameter(FFCompParameterID()[getParameterIndex(VParameter::ratio)])))
     {
         mRatioBox = std::make_unique<tote_bag::FlatTextChooser>(FFCompParameterLabel()[getParameterIndex(VParameter::ratio)],
                                                                 std::vector<std::string>{
@@ -182,7 +184,7 @@ void CenterPanel::resized()
     auto logoBounds = rightSideBounds.removeFromTop(logoHeight).removeFromLeft(paramWidth * numRightColumns).reduced(borderMargin);
     auto versionBounds = logoBounds.removeFromBottom(versionHeight);
 
-    vLogo->setTransformToFit(logoBounds.toFloat(), RectanglePlacement(RectanglePlacement::xMid |
-                                                                    RectanglePlacement::yTop));
+    vLogo->setTransformToFit(logoBounds.toFloat(), juce::RectanglePlacement(juce::RectanglePlacement::xMid |
+                                                                            juce::RectanglePlacement::yTop));
     versionLabel.setBounds(versionBounds);
 }

--- a/Source/GUI/Panels/ValentineCenterPanel.h
+++ b/Source/GUI/Panels/ValentineCenterPanel.h
@@ -10,12 +10,11 @@
 
 #pragma once
 
-#include <JuceHeader.h>
-
 #include "Common/GUI/Components/Widgets/LabelSlider.h"
 #include "Common/GUI/LookAndFeel/LookAndFeelConstants.h"
 #include "Common/GUI/Components/Widgets/FlatTextChooser.h"
 
+#include <juce_gui_basics/juce_gui_basics.h>
 
 //==============================================================================
 /*
@@ -33,17 +32,17 @@ public:
     void resized() override;
 
 private:
-    Rectangle<int> topLeftRowBorderBounds;
+    juce::Rectangle<int> topLeftRowBorderBounds;
     LabelSlider inputSlider;
     LabelSlider crushSlider;
     LabelSlider saturateSlider;
 
-    Rectangle<int> bottomLeftRowBorderBounds;
+    juce::Rectangle<int> bottomLeftRowBorderBounds;
     LabelSlider ratioSlider;
     LabelSlider attackSlider;
     LabelSlider releaseSlider;
 
-    Rectangle<int> topRightRowBorderBounds;
+    juce::Rectangle<int> topRightRowBorderBounds;
     LabelSlider mixSlider;
     LabelSlider outputSlider;
 

--- a/Source/GUI/Panels/ValentineMainPanel.h
+++ b/Source/GUI/Panels/ValentineMainPanel.h
@@ -10,23 +10,23 @@
 
 #pragma once
 
-#include "JuceHeader.h"
-
 #include "ValentineCenterPanel.h"
 
 #include "Common/GUI/LookAndFeel/LookAndFeel.h"
 #include "Common/GUI/Components/Panels/PresetPanel.h"
 #include "Common/GUI/Components/Panels/VerticalMeterPanel.h"
 
+#include <juce_gui_basics/juce_gui_basics.h>
+
 class ValentineAudioProcessor;
 
-class VMainPanel : public Component
+class VMainPanel : public juce::Component
 {
 public:
     VMainPanel(ValentineAudioProcessor& inProcessor);
     ~VMainPanel();
 
-    void paint (Graphics& g) override;
+    void paint (juce::Graphics& g) override;
 
     void resized() override;
 private:

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -42,7 +42,7 @@ ValentineAudioProcessorEditor::~ValentineAudioProcessorEditor()
 }
 
 //==============================================================================
-void ValentineAudioProcessorEditor::paint (Graphics& g)
+void ValentineAudioProcessorEditor::paint (juce::Graphics& g)
 {
 }
 

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -10,21 +10,24 @@
 
 #pragma once
 
-#include "../JuceLibraryCode/JuceHeader.h"
 #include "PluginProcessor.h"
+
 #include "GUI/Panels/ValentineMainPanel.h"
+
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
 
 //==============================================================================
 
-class ValentineAudioProcessorEditor  : public AudioProcessorEditor
+class ValentineAudioProcessorEditor  : public juce::AudioProcessorEditor
 {
 public:
     ValentineAudioProcessorEditor (ValentineAudioProcessor&);
     ~ValentineAudioProcessorEditor();
 
     //==============================================================================
-    void paint (Graphics&) override;
+    void paint (juce::Graphics&) override;
     void resized() override;
 
 private:

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -17,9 +17,9 @@ ValentineAudioProcessor::ValentineAudioProcessor()
      : AudioProcessor (BusesProperties()
                      #if ! JucePlugin_IsMidiEffect
                       #if ! JucePlugin_IsSynth
-                       .withInput  ("Input",  AudioChannelSet::stereo(), true)
+                       .withInput  ("Input",  juce::AudioChannelSet::stereo(), true)
                       #endif
-                       .withOutput ("Output", AudioChannelSet::stereo(), true)
+                       .withOutput ("Output", juce::AudioChannelSet::stereo(), true)
                      #endif
                        ),
                       treeState (*this, nullptr, "PARAMETER", createParameterLayout()),
@@ -57,11 +57,11 @@ ValentineAudioProcessor::~ValentineAudioProcessor()
 
 //==============================================================================
 
-AudioProcessorValueTreeState::ParameterLayout
+juce::AudioProcessorValueTreeState::ParameterLayout
 ValentineAudioProcessor::createParameterLayout()
 {
     testManager = juce::MessageManager::getInstance();
-    std::vector<std::unique_ptr<RangedAudioParameter>> params;
+    std::vector<std::unique_ptr<juce::RangedAudioParameter>> params;
 
     for (int i = 0; i < numParams; ++i)
     {
@@ -75,7 +75,8 @@ ValentineAudioProcessor::createParameterLayout()
             }
 
             const auto ratioParameterIndex = getParameterIndex(VParameter::ratio);
-            params.push_back(std::make_unique<AudioParameterChoice>(ParameterID{FFCompParameterID()[ratioParameterIndex], ValentineParameterVersion},
+            params.push_back(std::make_unique<juce::AudioParameterChoice>(
+                                                                    juce::ParameterID{FFCompParameterID()[ratioParameterIndex], ValentineParameterVersion},
                                                                     FFCompParameterLabel()[ratioParameterIndex],
                                                                     ratioChoices,
                                                                     FFCompParameterDefaults[ratioParameterIndex]));
@@ -83,19 +84,19 @@ ValentineAudioProcessor::createParameterLayout()
         else if (paramType == VParameter::nice ||
                  paramType == VParameter::bypass)
         {
-            params.push_back(std::make_unique<AudioParameterBool>(ParameterID{FFCompParameterID()[i], ValentineParameterVersion},
-                                                                  FFCompParameterLabel()[i],
-                                                                  false));
+            params.push_back(std::make_unique<juce::AudioParameterBool>(juce::ParameterID{FFCompParameterID()[i], ValentineParameterVersion},
+                                                                        FFCompParameterLabel()[i],
+                                                                        false));
 
         }
 
         else
         {
-            auto rangeToUse = NormalisableRange<float>(FFCompParameterMin[i],
-                                                       FFCompParameterMax[i],
-                                                       FFCompParameterIncrement[i]);
+            auto rangeToUse = juce::NormalisableRange<float>(FFCompParameterMin[i],
+                                                             FFCompParameterMax[i],
+                                                             FFCompParameterIncrement[i]);
             rangeToUse.setSkewForCentre(FFCompParamCenter[i]);
-            std::function<String(float value, int maximumStringLength)> stringFromValue = nullptr;
+            std::function<juce::String(float value, int maximumStringLength)> stringFromValue = nullptr;
 
             if ((paramType == VParameter::attack)    ||
                 (paramType == VParameter::release)   ||
@@ -123,17 +124,17 @@ ValentineAudioProcessor::createParameterLayout()
                 stringFromValue =
                 [](int value, int)
                 {
-                    return String(value);
+                    return juce::String(value);
                 };
 
             }
-                params.push_back( std::make_unique<AudioParameterFloat>
+                params.push_back( std::make_unique<juce::AudioParameterFloat>
                                  (juce::ParameterID{FFCompParameterID()[i], ValentineParameterVersion},
                                   FFCompParameterLabel()[i],
                                   rangeToUse,
                                   FFCompParameterDefaults[i],
                                   VParameterUnit()[i],
-                                  AudioProcessorParameter::genericParameter,
+                                  juce::AudioProcessorParameter::genericParameter,
                                   stringFromValue,
                                   nullptr));
             }
@@ -145,7 +146,7 @@ ValentineAudioProcessor::createParameterLayout()
 
 //==============================================================================
 
-const String ValentineAudioProcessor::getName() const
+const juce::String ValentineAudioProcessor::getName() const
 {
     return JucePlugin_Name;
 }
@@ -197,12 +198,12 @@ void ValentineAudioProcessor::setCurrentProgram (int index)
 {
 }
 
-const String ValentineAudioProcessor::getProgramName (int index)
+const juce::String ValentineAudioProcessor::getProgramName (int index)
 {
     return {};
 }
 
-void ValentineAudioProcessor::changeProgramName (int index, const String& newName)
+void ValentineAudioProcessor::changeProgramName (int index, const juce::String& newName)
 {
 }
 
@@ -276,8 +277,8 @@ bool ValentineAudioProcessor::isBusesLayoutSupported (const BusesLayout& layouts
   #else
     // This is the place where you check if the layout is supported.
     // In this template code we only support mono or stereo.
-    if (layouts.getMainOutputChannelSet() != AudioChannelSet::mono()
-     && layouts.getMainOutputChannelSet() != AudioChannelSet::stereo())
+    if (layouts.getMainOutputChannelSet() != juce::AudioChannelSet::mono()
+     && layouts.getMainOutputChannelSet() != juce::AudioChannelSet::stereo())
         return false;
 
     // This checks if the input layout matches the output layout
@@ -291,9 +292,9 @@ bool ValentineAudioProcessor::isBusesLayoutSupported (const BusesLayout& layouts
 }
 #endif
 
-void ValentineAudioProcessor::processBlock (AudioBuffer<float>& buffer, MidiBuffer& midiMessages)
+void ValentineAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages)
 {
-    ScopedNoDenormals noDenormals;
+    juce::ScopedNoDenormals noDenormals;
     auto totalNumInputChannels  = getTotalNumInputChannels();
     auto totalNumOutputChannels = getTotalNumOutputChannels();
     auto currentSamplesPerBlock = getBlockSize();
@@ -334,8 +335,8 @@ void ValentineAudioProcessor::processBlock (AudioBuffer<float>& buffer, MidiBuff
     currentGain = g;
 
     // Upsample then do non-linear processing
-    dsp::AudioBlock<float> processBlock (processBuffer);
-    dsp::AudioBlock<float> highSampleRateBlock = oversampler->processSamplesUp (processBlock);
+    juce::dsp::AudioBlock<float> processBlock (processBuffer);
+    juce::dsp::AudioBlock<float> highSampleRateBlock = oversampler->processSamplesUp (processBlock);
 
     ffCompressor->process(highSampleRateBlock);
     saturator->processBlock(highSampleRateBlock);
@@ -345,7 +346,7 @@ void ValentineAudioProcessor::processBlock (AudioBuffer<float>& buffer, MidiBuff
     // Delay processed signal to produce a integral delay amount
     for (int channel = 0; channel < totalNumOutputChannels; ++channel)
     {
-        dsp::AudioBlock<float> channelBlock = processBlock.getSingleChannelBlock(channel);
+        juce::dsp::AudioBlock<float> channelBlock = processBlock.getSingleChannelBlock(channel);
         fracDelayFilters[channel]->process(channelBlock);
     }
 
@@ -376,9 +377,9 @@ void ValentineAudioProcessor::processBlock (AudioBuffer<float>& buffer, MidiBuff
     outputMeterSource.measureBlock (buffer);
 }
 
-void ValentineAudioProcessor::processBlockBypassed (AudioBuffer<float>& buffer, MidiBuffer&)
+void ValentineAudioProcessor::processBlockBypassed (juce::AudioBuffer<float>& buffer, juce::MidiBuffer&)
 {
-    ScopedNoDenormals noDenormals;
+    juce::ScopedNoDenormals noDenormals;
 
     auto totalNumInputChannels  = getTotalNumInputChannels();
     auto totalNumOutputChannels = getTotalNumOutputChannels();
@@ -390,7 +391,7 @@ void ValentineAudioProcessor::processBlockBypassed (AudioBuffer<float>& buffer, 
                        currentSamplesPerBlock);
 }
 
-void ValentineAudioProcessor::prepareInputBuffer (AudioBuffer<float>& buffer,
+void ValentineAudioProcessor::prepareInputBuffer (juce::AudioBuffer<float>& buffer,
                                                   const int numInputChannels,
                                                   const int numOutputChannels,
                                                   const int samplesPerBlock)
@@ -417,24 +418,24 @@ bool ValentineAudioProcessor::hasEditor() const
     return true; // (change this to false if you choose to not supply an editor)
 }
 
-AudioProcessorEditor* ValentineAudioProcessor::createEditor()
+juce::AudioProcessorEditor* ValentineAudioProcessor::createEditor()
 {
     return new ValentineAudioProcessorEditor (*this);
 }
 
 //==============================================================================
 
-void ValentineAudioProcessor::parameterChanged (const String& parameter, float newValue)
+void ValentineAudioProcessor::parameterChanged (const juce::String& parameter, float newValue)
 {
 
     if (parameter == "Crush")
     {
         const auto bitCrushIndex = static_cast<int>(VParameter::bitCrush);
-        bitCrush->setParams(jmap(newValue,
-                                 FFCompParameterMin[bitCrushIndex],
-                                 FFCompParameterMax[bitCrushIndex],
-                                 17.0f,
-                                 3.0f)
+        bitCrush->setParams(juce::jmap(newValue,
+                                  FFCompParameterMin[bitCrushIndex],
+                                  FFCompParameterMax[bitCrushIndex],
+                                  17.0f,
+                                  3.0f)
                             );
         if (newValue >= 1.0001f)
             crushOn.set(true);
@@ -444,11 +445,11 @@ void ValentineAudioProcessor::parameterChanged (const String& parameter, float n
     else if (parameter == "Saturation")
     {
         const auto saturateIndex = static_cast<int>(VParameter::saturation);
-        saturator->setParams(jmap(newValue,
-                                  FFCompParameterMin[saturateIndex],
-                                  FFCompParameterMax[saturateIndex],
-                                  kMinSaturationGain,
-                                  kMaxSaturationGain));
+        saturator->setParams(juce::jmap(newValue,
+                                        FFCompParameterMin[saturateIndex],
+                                        FFCompParameterMax[saturateIndex],
+                                        kMinSaturationGain,
+                                        kMaxSaturationGain));
     }
     else if (parameter == "AttackTime")
     {
@@ -467,7 +468,7 @@ void ValentineAudioProcessor::parameterChanged (const String& parameter, float n
     }
     else if (parameter == "Compress")
     {
-        compressValue.set(Decibels::decibelsToGain(newValue));
+        compressValue.set(juce::Decibels::decibelsToGain(newValue));
     }
     else if (parameter == "Mix")
     {
@@ -475,7 +476,7 @@ void ValentineAudioProcessor::parameterChanged (const String& parameter, float n
     }
     else if (parameter == "Makeup")
     {
-        makeupValue.set(Decibels::decibelsToGain(newValue));
+        makeupValue.set(juce::Decibels::decibelsToGain(newValue));
     }
     else if (parameter == "Nice")
     {
@@ -491,7 +492,7 @@ void ValentineAudioProcessor::parameterChanged (const String& parameter, float n
 }
 
 //==============================================================================
-void ValentineAudioProcessor::getStateInformation (MemoryBlock& destData)
+void ValentineAudioProcessor::getStateInformation (juce::MemoryBlock& destData)
 {
     // You should use this method to store your parameters in the memory block.
     // You could do that either as raw data, or use the XML or ValueTree classes
@@ -502,9 +503,9 @@ void ValentineAudioProcessor::getStateInformation (MemoryBlock& destData)
     auto currentPresetName = presetManager.getCurrentPresetName();
 
     if (currentPresetName.isNotEmpty())
-        state.setProperty(Identifier ("PresetName"), currentPresetName, nullptr);
+        state.setProperty(juce::Identifier ("PresetName"), currentPresetName, nullptr);
 
-    std::unique_ptr<XmlElement> xml (state.createXml());
+    std::unique_ptr<juce::XmlElement> xml (state.createXml());
 
     copyXmlToBinary (*xml, destData);
 
@@ -514,15 +515,15 @@ void ValentineAudioProcessor::setStateInformation (const void* data, int sizeInB
 {
     // You should use this method to restore your parameters from this memory block,
     // whose contents will have been created by the getStateInformation() call.
-    std::unique_ptr<XmlElement> xmlState (getXmlFromBinary (data, sizeInBytes));
+    std::unique_ptr<juce::XmlElement> xmlState (getXmlFromBinary (data, sizeInBytes));
 
     if (xmlState.get() != nullptr)
     {
         if (xmlState->hasTagName (treeState.state.getType()))
         {
-            auto newTree = ValueTree::fromXml (*xmlState);
+            auto newTree = juce::ValueTree::fromXml (*xmlState);
 
-            auto presetID = Identifier("PresetName");
+            auto presetID = juce::Identifier("PresetName");
             if (newTree.hasProperty (presetID))
             {
                 presetManager.setLastChosenPresetName (newTree.getPropertyAsValue ("PresetName", nullptr).toString());
@@ -566,7 +567,7 @@ void ValentineAudioProcessor::initializeDSP()
 //==============================================================================
 
 // This creates new instances of the plugin..
-AudioProcessor* JUCE_CALLTYPE createPluginFilter()
+juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter()
 {
     return new ValentineAudioProcessor();
 }

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -10,8 +10,6 @@
 
 #pragma once
 
-#include <juce_audio_processors/juce_audio_processors.h>
-
 #include "ValentineParameters.h"
 
 #include "Common/DSP/Compressor.h"
@@ -21,6 +19,7 @@
 #include "Common/DSP/CircularBuffer.h"
 #include "Common/GUI/Managers/ToteBagPresetManager.h"
 
+#include <juce_audio_processors/juce_audio_processors.h>
 
 //==============================================================================
 /**

--- a/libs/Common/DSP/EnvelopeDetector.cpp
+++ b/libs/Common/DSP/EnvelopeDetector.cpp
@@ -8,11 +8,11 @@
   ==============================================================================
 */
 
-
-
 #include "EnvelopeDetector.h"
-#include "JuceHeader.h"
 #include "AudioHelpers.h"
+
+#include <juce_dsp/juce_dsp.h>
+
 #include <math.h>
 
 EnvelopeDetector::EnvelopeDetector (bool autoReleaseFlag) :
@@ -80,7 +80,7 @@ inline double EnvelopeDetector::getReleaseCoefficient()
 
 double EnvelopeDetector::processSampleDecoupledBranched (double inputSample)
 {
-    ScopedNoDenormals noDenormals;
+    juce::ScopedNoDenormals noDenormals;
     
     auto prevOutput = prevEnv.get();
     auto coeff  = inputSample > prevOutput ? tauAttack.get() : tauRelease.get();

--- a/libs/Common/GUI/Components/Panels/PresetPanel.cpp
+++ b/libs/Common/GUI/Components/Panels/PresetPanel.cpp
@@ -36,16 +36,16 @@ PresetPanel::PresetPanel (ToteBagPresetManager& pManager,
     addAndMakeVisible (mBypassButton);
 
     // set up preset combo box
-    mPresetDisplay.setColour (ComboBox::ColourIds::backgroundColourId, Colours::black);
-    mPresetDisplay.setColour (ComboBox::ColourIds::textColourId, Colours::darkgrey);
-    mPresetDisplay.setColour (ComboBox::ColourIds::outlineColourId, Colours::grey);
+    mPresetDisplay.setColour (juce::ComboBox::ColourIds::backgroundColourId, juce::Colours::black);
+    mPresetDisplay.setColour (juce::ComboBox::ColourIds::textColourId, juce::Colours::darkgrey);
+    mPresetDisplay.setColour (juce::ComboBox::ColourIds::outlineColourId, juce::Colours::grey);
 
     addAndMakeVisible (mPresetDisplay);
     mPresetDisplay.onChange = [this]() {
         handlePresetDisplaySelection();
     };
-    mPresetDisplay.setText (currentPresetName, dontSendNotification);
-    mPresetDisplay.setSelectedItemIndex(presetManager.getCurrentPresetIndex(), dontSendNotification);
+    mPresetDisplay.setText (currentPresetName, juce::dontSendNotification);
+    mPresetDisplay.setSelectedItemIndex(presetManager.getCurrentPresetIndex(), juce::dontSendNotification);
 
     updatePresetComboBox();
 
@@ -66,9 +66,9 @@ PresetPanel::~PresetPanel()
     stopTimer();
 }
 
-void PresetPanel::paint(Graphics& g)
+void PresetPanel::paint(juce::Graphics& g)
 {
-    g.setColour(Colours::darkgrey);
+    g.setColour(juce::Colours::darkgrey);
     g.fillAll();
 }
 
@@ -96,16 +96,16 @@ void PresetPanel::savePreset()
 {
     auto currentPresetName = presetManager.getCurrentPresetName();
 
-    String currentPresetPath = presetManager.getCurrentPresetDirectory()
+    juce::String currentPresetPath = presetManager.getCurrentPresetDirectory()
                                + static_cast<std::string>(directorySeparator) + currentPresetName;
 
-    FileChooser chooser ("Save a file: ",
-                         File (currentPresetPath),
-                         static_cast<std::string>(presetFileExtensionWildcard));
+    juce::FileChooser chooser ("Save a file: ",
+                               juce::File (currentPresetPath),
+                               static_cast<std::string>(presetFileExtensionWildcard));
 
     if (chooser.browseForFileToSave (true))
     {
-        File presetToSave (chooser.getResult());
+        juce::File presetToSave (chooser.getResult());
 
         presetManager.savePreset (presetToSave);
 
@@ -115,19 +115,19 @@ void PresetPanel::savePreset()
 
 void PresetPanel::loadPreset()
 {
-    String currentPresetDirectory = presetManager.getCurrentPresetDirectory();
+    juce::String currentPresetDirectory = presetManager.getCurrentPresetDirectory();
 
     if (currentPresetDirectory.isNotEmpty())
     {
 
-        FileChooser chooser ("Load a file: ",
-                            File (currentPresetDirectory),
-                            static_cast<std::string>(presetFileExtensionWildcard));
+        juce::FileChooser chooser ("Load a file: ",
+                                   juce::File (currentPresetDirectory),
+                                   static_cast<std::string>(presetFileExtensionWildcard));
 
         if (chooser.browseForFileToOpen())
         {
-            File presetToLoad (chooser.getResult());
-            
+            juce::File presetToLoad (chooser.getResult());
+
             presetManager.loadPreset (presetToLoad);
 
         }
@@ -145,21 +145,17 @@ void PresetPanel::handlePresetDisplaySelection()
 
 void PresetPanel::timerCallback()
 {
-
     auto presetNameInManager = presetManager.getCurrentPresetName();
     if (currentPresetName != presetNameInManager)
     {
-        mPresetDisplay.setText (presetNameInManager, dontSendNotification);
+        mPresetDisplay.setText (presetNameInManager, juce::dontSendNotification);
         currentPresetName = presetNameInManager;
-        
     }
-    
 }
 
 void PresetPanel::updatePresetComboBox()
 {
-    
-    mPresetDisplay.clear (dontSendNotification);
+    mPresetDisplay.clear (juce::dontSendNotification);
 
     const int numPresets = presetManager.getNumberOfPresets();
 
@@ -167,9 +163,8 @@ void PresetPanel::updatePresetComboBox()
     {
         mPresetDisplay.addItem (presetManager.getPresetName (i), (i+1));
     }
-        
-    mPresetDisplay.setText (presetManager.getCurrentPresetName(), dontSendNotification);
-    
+
+    mPresetDisplay.setText (presetManager.getCurrentPresetName(), juce::dontSendNotification);
 }
 
 void PresetPanel::resized()

--- a/libs/Common/GUI/Components/Panels/PresetPanel.h
+++ b/libs/Common/GUI/Components/Panels/PresetPanel.h
@@ -10,9 +10,9 @@
 
 #pragma once
 
-#include "JuceHeader.h"
-
 #include "Common/GUI/Components/Widgets/ParameterTextButton.h"
+
+#include <juce_gui_basics/juce_gui_basics.h>
 
 class ToteBagPresetManager;
 class PresetPanel  : public juce::Component,
@@ -26,7 +26,7 @@ public:
                  juce::AudioProcessorValueTreeState& treeState);
     ~PresetPanel();
     
-    void paint (Graphics& g) override;
+    void paint (juce::Graphics& g) override;
     
     void incrementPreset();
 
@@ -52,7 +52,7 @@ private:
     juce::TextButton mNextPreset;
     ParameterTextButton mBypassButton;
 
-    ComboBox mPresetDisplay;
+    juce::ComboBox mPresetDisplay;
 
     juce::String currentPresetName {"Untitled"};
     

--- a/libs/Common/GUI/Components/Panels/VerticalMeterPanel.cpp
+++ b/libs/Common/GUI/Components/Panels/VerticalMeterPanel.cpp
@@ -8,9 +8,11 @@
   ==============================================================================
 */
 
-#include <JuceHeader.h>
 #include "VerticalMeterPanel.h"
+
 #include "Common/GUI/LookAndFeel/LookAndFeelConstants.h"
+
+#include <juce_gui_basics/juce_gui_basics.h>
 
 //==============================================================================
 VerticalMeterPanel::VerticalMeterPanel(const juce::String& label,

--- a/libs/Common/GUI/Components/Panels/VerticalMeterPanel.h
+++ b/libs/Common/GUI/Components/Panels/VerticalMeterPanel.h
@@ -10,10 +10,9 @@
 
 #pragma once
 
-#include <JuceHeader.h>
-
 #include "Common/GUI/LookAndFeel/LookAndFeel.h"
 
+#include <juce_gui_basics/juce_gui_basics.h>
 
 //==============================================================================
 

--- a/libs/Common/GUI/Components/Widgets/FlatTextButton.cpp
+++ b/libs/Common/GUI/Components/Widgets/FlatTextButton.cpp
@@ -18,7 +18,7 @@ FlatTextButton::FlatTextButton(juce::String name) : TextButton(name)
 {    
 }
 
-void FlatTextButton::paintButton (Graphics& g, bool shouldDrawButtonAsHighlighted, bool shouldDrawButtonAsDown)
+void FlatTextButton::paintButton (juce::Graphics& g, bool shouldDrawButtonAsHighlighted, bool shouldDrawButtonAsDown)
 {
 
     if (auto* lnf = dynamic_cast<LookAndFeel*> (&getLookAndFeel()))

--- a/libs/Common/GUI/Components/Widgets/FlatTextButton.h
+++ b/libs/Common/GUI/Components/Widgets/FlatTextButton.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include <JuceHeader.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
 namespace tote_bag
 {
@@ -23,7 +23,9 @@ public:
     
 protected:
 
-    void paintButton (Graphics& g, bool shouldDrawButtonAsHighlighted, bool shouldDrawButtonAsDown) override;
+    void paintButton (juce::Graphics& g,
+                      bool shouldDrawButtonAsHighlighted,
+                      bool shouldDrawButtonAsDown) override;
 
 };
 }// namespace totebag

--- a/libs/Common/GUI/Components/Widgets/FlatTextChooser.cpp
+++ b/libs/Common/GUI/Components/Widgets/FlatTextChooser.cpp
@@ -8,8 +8,9 @@
   ==============================================================================
 */
 
-#include <JuceHeader.h>
 #include "FlatTextChooser.h"
+
+#include <juce_audio_processors/juce_audio_processors.h>
 
 //==============================================================================
 
@@ -25,8 +26,8 @@ FlatTextChooser::FlatTextChooser(const juce::String& labelText,
 ,mParameter(param)
 ,mAlignWithParameterSliders(alignWithParameterSliders)
 {
-    mLabel.setColour(Label::textColourId, Colours::black);
-    mLabel.setJustificationType(Justification::centredTop);
+    mLabel.setColour(juce::Label::textColourId, juce::Colours::black);
+    mLabel.setJustificationType(juce::Justification::centredTop);
 
     addAndMakeVisible(mLabel);
     

--- a/libs/Common/GUI/Components/Widgets/FlatTextChooser.h
+++ b/libs/Common/GUI/Components/Widgets/FlatTextChooser.h
@@ -13,9 +13,14 @@
 #include "Common/GUI/Managers/RadioButtonGroupManager.h"
 #include "Common/GUI/Components/Widgets/FlatTextButton.h"
 
-#include <JuceHeader.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
 //==============================================================================
+
+namespace juce
+{
+class AudioParameterChoice;
+} // namespace juce
 
 namespace tote_bag
 {

--- a/libs/Common/GUI/Components/Widgets/LabelSlider.cpp
+++ b/libs/Common/GUI/Components/Widgets/LabelSlider.cpp
@@ -8,8 +8,9 @@
   ==============================================================================
 */
 
-#include <JuceHeader.h>
 #include "LabelSlider.h"
+
+#include <juce_audio_processors/juce_audio_processors.h>
 
 //==============================================================================
 
@@ -17,9 +18,9 @@ LabelSlider::LabelSlider(const juce::String& parameterId,
                          juce::AudioProcessorValueTreeState& stateToControl) :
 slider(parameterId, stateToControl)
 {
-    label.setText(stateToControl.getParameter(parameterId)->name, dontSendNotification);
-    label.setColour(Label::textColourId, Colours::black);
-    label.setJustificationType(Justification::centredTop);
+    label.setText(stateToControl.getParameter(parameterId)->name, juce::dontSendNotification);
+    label.setColour(juce::Label::textColourId, juce::Colours::black);
+    label.setJustificationType(juce::Justification::centredTop);
 
     addAndMakeVisible(label);
     addAndMakeVisible(slider);

--- a/libs/Common/GUI/Components/Widgets/LabelSlider.h
+++ b/libs/Common/GUI/Components/Widgets/LabelSlider.h
@@ -10,13 +10,18 @@
 
 #pragma once
 
-#include <JuceHeader.h>
-
 #include "Common/GUI/Components/Widgets/ParameterSlider.h"
+
+#include <juce_gui_basics/juce_gui_basics.h>
 
 //==============================================================================
 /*
 */
+namespace juce
+{
+class AudioProcessorValueTreeState;
+}// namespace juce
+
 class LabelSlider  : public juce::Component
 {
 public:

--- a/libs/Common/GUI/Components/Widgets/ParameterSlider.h
+++ b/libs/Common/GUI/Components/Widgets/ParameterSlider.h
@@ -10,9 +10,11 @@
 
 #pragma once
 
-#include "JuceHeader.h"
+#include <juce_gui_basics/juce_gui_basics.h>
 
-class ParameterSlider : public Slider
+#include <juce_audio_processors/juce_audio_processors.h>
+
+class ParameterSlider : public juce::Slider
 {
 public:
 
@@ -23,6 +25,6 @@ private:
 
     std::unique_ptr<juce::AudioProcessorValueTreeState::SliderAttachment> sliderValue;
 
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ParameterSlider);
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ParameterSlider)
 };
 

--- a/libs/Common/GUI/Components/Widgets/ParameterTextButton.cpp
+++ b/libs/Common/GUI/Components/Widgets/ParameterTextButton.cpp
@@ -12,7 +12,7 @@
 
 ParameterTextButton::ParameterTextButton (const juce::String& buttonText,
                                           const juce::String& parameterId,
-                                          AudioProcessorValueTreeState& stateToControl) :
+                                          juce::AudioProcessorValueTreeState& stateToControl) :
 buttonValue(stateToControl, parameterId, *this)
 {
     setButtonText(buttonText);

--- a/libs/Common/GUI/Components/Widgets/ParameterTextButton.h
+++ b/libs/Common/GUI/Components/Widgets/ParameterTextButton.h
@@ -9,17 +9,19 @@
 */
 
 #pragma once
-#include "JuceHeader.h"
 
-class ParameterTextButton : public TextButton
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <juce_audio_processors/juce_audio_processors.h>
+
+class ParameterTextButton : public juce::TextButton
 {
 public:
     ParameterTextButton (const juce::String& buttonText,
                          const juce::String& parameterId,
-                         AudioProcessorValueTreeState& stateToControl);
+                         juce::AudioProcessorValueTreeState& stateToControl);
 
 private:
-    AudioProcessorValueTreeState::ButtonAttachment buttonValue;
+    juce::AudioProcessorValueTreeState::ButtonAttachment buttonValue;
     
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ParameterTextButton)
 };

--- a/libs/Common/GUI/LookAndFeel/LookAndFeel.cpp
+++ b/libs/Common/GUI/LookAndFeel/LookAndFeel.cpp
@@ -10,16 +10,18 @@
 
 #include "LookAndFeel.h"
 #include "LookAndFeelConstants.h"
+
 #include "Common/GUI/Components/Widgets/FlatTextButton.h"
 
+#include "BinaryData.h"
 
 namespace
 {
-const Font getCustomFont()
+const juce::Font getCustomFont()
 {
-    static auto typeface = Typeface::createSystemTypefaceFor (BinaryData::MontserratMedium_ttf,
-                                                              BinaryData::MontserratMedium_ttfSize);
-    return Font (typeface);
+    static auto typeface = juce::Typeface::createSystemTypefaceFor (BinaryData::MontserratMedium_ttf,
+                                                                    BinaryData::MontserratMedium_ttfSize);
+    return juce::Font (typeface);
 }
 }
 
@@ -38,24 +40,24 @@ LookAndFeel::LookAndFeel()
     setColour(ColourIds::pointerColourId, juce::Colours::black);
 
     // slider text box colours
-    setColour(juce::Slider::textBoxTextColourId, Colours::black);
+    setColour(juce::Slider::textBoxTextColourId, juce::Colours::black);
     setColour(juce::Slider::textBoxOutlineColourId, vPinkDark);
     setColour(juce::Slider::rotarySliderOutlineColourId, vPinkDark);
-    setColour(juce::Slider::rotarySliderFillColourId, Colours::floralwhite);
+    setColour(juce::Slider::rotarySliderFillColourId, juce::Colours::floralwhite);
 }
 
-void LookAndFeel::drawSliderMeter(Graphics& g,
-                                   const Rectangle<float> bounds,
+void LookAndFeel::drawSliderMeter(juce::Graphics& g,
+                                   const juce::Rectangle<float> bounds,
                                    const float lineWidth,
                                    const float radius,
                                    const float startAngle, float endAngle,
                                    const float toAngle,
-                                   Slider& slider)
+                                  juce::Slider& slider)
 {
-    auto outline = slider.findColour (Slider::rotarySliderOutlineColourId);
-    auto fill    = slider.findColour (Slider::rotarySliderFillColourId);
+    auto outline = slider.findColour (juce::Slider::rotarySliderOutlineColourId);
+    auto fill    = slider.findColour (juce::Slider::rotarySliderFillColourId);
 
-    Path backgroundArc;
+    juce::Path backgroundArc;
     backgroundArc.addCentredArc (bounds.getCentreX(),
                                  bounds.getCentreY(),
                                  radius,
@@ -66,11 +68,14 @@ void LookAndFeel::drawSliderMeter(Graphics& g,
                                  true);
 
     g.setColour (outline);
-    g.strokePath (backgroundArc, PathStrokeType (lineWidth, PathStrokeType::curved, PathStrokeType::butt));
+    g.strokePath (backgroundArc,
+                  juce::PathStrokeType (lineWidth,
+                                        juce::PathStrokeType::curved,
+                                        juce::PathStrokeType::butt));
 
     if (slider.isEnabled())
     {
-        Path valueArc;
+        juce::Path valueArc;
         valueArc.addCentredArc (bounds.getCentreX(),
                                 bounds.getCentreY(),
                                 radius,
@@ -81,39 +86,42 @@ void LookAndFeel::drawSliderMeter(Graphics& g,
                                 true);
 
         g.setColour (fill);
-        g.strokePath (valueArc, PathStrokeType (lineWidth, PathStrokeType::curved, PathStrokeType::butt));
+        g.strokePath (valueArc,
+                      juce::PathStrokeType (lineWidth,
+                                            juce::PathStrokeType::curved,
+                                            juce::PathStrokeType::butt));
     }
 }
 
-void LookAndFeel::drawDrawableKnob(Graphics& g,
+void LookAndFeel::drawDrawableKnob(juce::Graphics& g,
                                    const float radius,
                                    const float drawableWidth,
-                                   Drawable& sliderImage,
+                                   juce::Drawable& sliderImage,
                                    const float toAngle,
-                                   const Rectangle<float> bounds)
+                                   const juce::Rectangle<float> bounds)
 {
     const auto rw = radius * 2.0f;
     const auto realW = rw / drawableWidth;
 
     const auto halfDrawableWidth = drawableWidth / 2.0f;
 
-    sliderImage.setTransform(AffineTransform::rotation(toAngle,
-                                                  halfDrawableWidth,
-                                                  halfDrawableWidth).scaled(realW,
-                                                                            realW,
-                                                                            halfDrawableWidth,
-                                                                            halfDrawableWidth));
+    sliderImage.setTransform(juce::AffineTransform::rotation(toAngle,
+                                                             halfDrawableWidth,
+                                                             halfDrawableWidth).scaled(realW,
+                                                                                       realW,
+                                                                                       halfDrawableWidth,
+                                                                                       halfDrawableWidth));
 
     const auto cX = bounds.getCentreX() - halfDrawableWidth;
     const auto cY = bounds.getCentreY() - halfDrawableWidth;
     sliderImage.drawAt(g, cX, cY, 1.0f);
 }
 
-void LookAndFeel::drawKnob(Graphics& g,
+void LookAndFeel::drawKnob(juce::Graphics& g,
                             const float radius,
                             const float toAngle,
-                            const Rectangle<float> bounds,
-                            Slider& slider,
+                            const juce::Rectangle<float> bounds,
+                            juce::Slider& slider,
                             const bool withDropShadow)
 {
     const auto centreX = bounds.getCentreX();
@@ -129,7 +137,7 @@ void LookAndFeel::drawKnob(Graphics& g,
     g.fillEllipse (rx, ry, rw, rw);
 
     // Get thicknesses for outline rings...
-    const auto innerOutlineThickness = jmax((rw * .05f), 1.0f);
+    const auto innerOutlineThickness = juce::jmax((rw * .05f), 1.0f);
     const auto outerOutlineThickness = innerOutlineThickness * .15f;
 
     // Offset inner outline by its thickness
@@ -152,13 +160,13 @@ void LookAndFeel::drawKnob(Graphics& g,
     if (withDropShadow)
     {
 
-        auto xOffset = jmin(roundToInt(innerOutlineThickness * .25), 1);
-        auto yOffset = jmin(roundToInt(innerOutlineThickness * .5), 1);
+        auto xOffset = juce::jmin(juce::roundToInt(innerOutlineThickness * .25), 1);
+        auto yOffset = juce::jmin(juce::roundToInt(innerOutlineThickness * .5), 1);
 
-        auto shadow = DropShadow(fillColour.darker(),
-                                 innerOutlineThickness,
-                                 {xOffset, yOffset});
-        Path shadowPath;
+        auto shadow = juce::DropShadow(fillColour.darker(),
+                                       innerOutlineThickness,
+                                       {xOffset, yOffset});
+        juce::Path shadowPath;
         shadowPath.addEllipse(outerOutlineRx, outerOutlineRy, outerOutlineRw, outerOutlineRw);
         shadow.drawForPath(g, shadowPath);
     }
@@ -185,16 +193,16 @@ void LookAndFeel::drawKnob(Graphics& g,
     g.fillPath (p);
 }
 
-void LookAndFeel::drawRotarySlider (Graphics& g,
-                                     int x, int y,
-                                     int width, int height,
-                                     float sliderPos,
-                                     const float rotaryStartAngle, const float rotaryEndAngle,
-                                     Slider& slider)
+void LookAndFeel::drawRotarySlider (juce::Graphics& g,
+                                    int x, int y,
+                                    int width, int height,
+                                    float sliderPos,
+                                    const float rotaryStartAngle, const float rotaryEndAngle,
+                                    juce::Slider& slider)
 {
 
-    auto bounds = Rectangle<int> (x, y, width, height).toFloat().reduced (10);
-    auto radius = jmin (bounds.getWidth(), bounds.getHeight()) / 2.0f;
+    auto bounds = juce::Rectangle<int> (x, y, width, height).toFloat().reduced (10);
+    auto radius = juce::jmin (bounds.getWidth(), bounds.getHeight()) / 2.0f;
     auto lineW = radius * 0.125f;
     auto arcRadius = radius - lineW * 0.5f;
     const auto toAngle = rotaryStartAngle + sliderPos * (rotaryEndAngle - rotaryStartAngle);
@@ -208,26 +216,26 @@ void LookAndFeel::drawRotarySlider (Graphics& g,
         
 //=============================================================================
 
-Typeface::Ptr LookAndFeel::getTypefaceForFont (const Font& f)
+juce::Typeface::Ptr LookAndFeel::getTypefaceForFont (const juce::Font& f)
 {
     return getCustomFont().getTypefacePtr();
 }
 
-Font LookAndFeel::getTextButtonFont (TextButton& b, int buttonHeight)
+juce::Font LookAndFeel::getTextButtonFont (juce::TextButton& b, int buttonHeight)
 {
-    return  {jmax (7.0f, buttonHeight * 0.8f)};
+    return  {juce::jmax (7.0f, buttonHeight * 0.8f)};
 }
     
-Font LookAndFeel::getLabelFont (Label& l)
+juce::Font LookAndFeel::getLabelFont (juce::Label& l)
 {
     return { static_cast<float>(l.getHeight()) };
 }
     
-    void LookAndFeel::drawButtonBackground (Graphics& g,
-                                             Button& button,
-                                             const Colour& backgroundColour,
-                                             bool,
-                                             bool isButtonDown)
+    void LookAndFeel::drawButtonBackground (juce::Graphics& g,
+                                            juce::Button& button,
+                                            const juce::Colour& backgroundColour,
+                                            bool,
+                                            bool isButtonDown)
     {
         auto buttonArea = button.getLocalBounds();
         const auto h = buttonArea.getHeight();
@@ -239,15 +247,15 @@ Font LookAndFeel::getLabelFont (Label& l)
         g.fillRoundedRectangle(buttonArea.toFloat(), cornerSize);
     }
 
-void LookAndFeel::drawFlatButtonBackground (Graphics& g,
-                                             tote_bag::FlatTextButton& button,
-                                             const Colour& backgroundColour,
-                                             bool shouldDrawButtonAsHighlighted,
-                                             bool shouldDrawButtonAsDown)
+void LookAndFeel::drawFlatButtonBackground (juce::Graphics& g,
+                                            tote_bag::FlatTextButton& button,
+                                            const juce::Colour& backgroundColour,
+                                            bool shouldDrawButtonAsHighlighted,
+                                            bool shouldDrawButtonAsDown)
 {
     auto bounds = button.getLocalBounds().toFloat();
 
-    auto r = jmin(bounds.getWidth(), bounds.getHeight());
+    auto r = juce::jmin(bounds.getWidth(), bounds.getHeight());
     auto cornerSize = r * .5f;
 
     auto baseColour = backgroundColour.withMultipliedSaturation (button.hasKeyboardFocus (true) ? 1.3f : 0.9f)
@@ -265,7 +273,7 @@ void LookAndFeel::drawFlatButtonBackground (Graphics& g,
 
     if (flatOnLeft || flatOnRight || flatOnTop || flatOnBottom)
     {
-        Path path;
+        juce::Path path;
         path.addRoundedRectangle (bounds.getX(), bounds.getY(),
                                   bounds.getWidth(), bounds.getHeight(),
                                   cornerSize, cornerSize,
@@ -282,20 +290,23 @@ void LookAndFeel::drawFlatButtonBackground (Graphics& g,
     }
 }
 
-    void LookAndFeel::drawButtonText (Graphics& g, TextButton& button, bool, bool isButtonDown)
+    void LookAndFeel::drawButtonText (juce::Graphics& g,
+                                      juce::TextButton& button,
+                                      bool,
+                                      bool isButtonDown)
     {
         auto font = getTextButtonFont (button, button.getHeight());
         g.setFont (font);
-        g.setColour (button.findColour (isButtonDown ? TextButton::textColourOnId
-                                                                : TextButton::textColourOffId)
+        g.setColour (button.findColour (isButtonDown ? juce::TextButton::textColourOnId
+                                                     : juce::TextButton::textColourOffId)
                            .withMultipliedAlpha (button.isEnabled() ? 1.0f : 0.5f));
 
-        auto yIndent = jmin (4, button.proportionOfHeight (0.5f));
-        auto cornerSize = jmin (button.getHeight(), button.getWidth()) / 2;
+        auto yIndent = juce::jmin (4, button.proportionOfHeight (0.5f));
+        auto cornerSize = juce::jmin (button.getHeight(), button.getWidth()) / 2;
 
-        auto fontHeight = roundToInt (font.getHeight() * 0.6f);
-        auto leftIndent  = jmin (fontHeight, 2 + cornerSize / (button.isConnectedOnLeft()  ? 4 : 2));
-        auto rightIndent = jmin (fontHeight, 2 + cornerSize / (button.isConnectedOnRight() ? 4 : 2));
+        auto fontHeight = juce::roundToInt (font.getHeight() * 0.6f);
+        auto leftIndent  = juce::jmin (fontHeight, 2 + cornerSize / (button.isConnectedOnLeft()  ? 4 : 2));
+        auto rightIndent = juce::jmin (fontHeight, 2 + cornerSize / (button.isConnectedOnRight() ? 4 : 2));
         auto textWidth = button.getWidth() - leftIndent - rightIndent;
 
         //auto edge = 4;
@@ -303,53 +314,64 @@ void LookAndFeel::drawFlatButtonBackground (Graphics& g,
 
         if (textWidth > 0)
             g.drawFittedText (button.getButtonText(),
-                              leftIndent, yIndent, textWidth, button.getHeight() - yIndent * 2,
-                              Justification::centred, 2);
+                              leftIndent, yIndent,
+                              textWidth, button.getHeight() - yIndent * 2,
+                              juce::Justification::centred, 2);
     }
 
-    void LookAndFeel::drawComboBox (Graphics& g, int width, int height, bool,
-                                       int, int, int, int, ComboBox& box)
+    void LookAndFeel::drawComboBox (juce::Graphics& g,
+                                    int width, int height,
+                                    bool,
+                                    int, int, int, int,
+                                    juce::ComboBox& box)
     {
         const auto boxBounds = box.getLocalBounds();
 
-        const auto fontHeight = jmax (7.0f, height * 0.6f);
-        g.setFont(Font(fontHeight));
+        const auto fontHeight = juce::jmax (7.0f, height * 0.6f);
+        g.setFont(juce::Font(fontHeight));
 
-        g.setColour (box.findColour (ComboBox::backgroundColourId));
+        g.setColour (box.findColour (juce::ComboBox::backgroundColourId));
 
         const auto h = boxBounds.getHeight();
         const auto cornerSize = h * .15f;
         g.fillRoundedRectangle(boxBounds.toFloat(), cornerSize);
     }
 
-    void LookAndFeel::drawPopupMenuItem (Graphics& g, const Rectangle<int>& area,
-                              bool isSeparator, bool isActive, bool isHighlighted, bool isTicked, bool hasSubMenu,
-                              const String& text, const String& shortcutKeyText,
-                              const Drawable* icon, const Colour* textColour)
+    void LookAndFeel::drawPopupMenuItem (juce::Graphics& g,
+                                         const juce::Rectangle<int>& area,
+                                         bool isSeparator,
+                                         bool isActive,
+                                         bool isHighlighted,
+                                         bool isTicked,
+                                         bool hasSubMenu,
+                                         const juce::String& text,
+                                         const juce::String& shortcutKeyText,
+                                         const juce::Drawable* icon,
+                                         const juce::Colour* textColour)
       {
           using namespace laf_constants;
 
           juce::Rectangle<int> r (area);
 
-          Colour fillColour = isHighlighted ? vColour_5 : vColour_4;
+          juce::Colour fillColour = isHighlighted ? vColour_5 : vColour_4;
           g.setColour(fillColour);
           g.fillRect(r.getX(), r.getY(), r.getWidth(), r.getHeight() - 1 );
 
-          Colour myTextColour = isTicked ? vColour_7 : vColour_1;
+          juce::Colour myTextColour = isTicked ? vColour_7 : vColour_1;
           g.setColour(myTextColour);
 
-          auto fHeight = jmax (7.0f, r.getHeight() * 0.6f);
-          g.setFont(Font(fHeight));
+          auto fHeight = juce::jmax (7.0f, r.getHeight() * 0.6f);
+          g.setFont(juce::Font(fHeight));
 
           r.setLeft(10);
           r.setY(1);
-          g.drawFittedText(text, r, Justification::left, 1);
+          g.drawFittedText(text, r, juce::Justification::left, 1);
 
       }
     
     
     
-    Slider::SliderLayout LookAndFeel::getSliderLayout (Slider& slider)
+    juce::Slider::SliderLayout LookAndFeel::getSliderLayout (juce::Slider& slider)
     {
         // 1. compute the actually visible textBox size from the slider textBox size and some additional constraints
 
@@ -358,7 +380,7 @@ void LookAndFeel::drawFlatButtonBackground (Graphics& g,
 
         auto textBoxPos = slider.getTextBoxPosition();
 
-        if (textBoxPos == Slider::TextBoxLeft || textBoxPos == Slider::TextBoxRight)
+        if (textBoxPos == juce::Slider::TextBoxLeft || textBoxPos == juce::Slider::TextBoxRight)
             minXSpace = 30;
         else
             minYSpace = 15;
@@ -366,15 +388,15 @@ void LookAndFeel::drawFlatButtonBackground (Graphics& g,
         auto localBounds = slider.getLocalBounds();
 
         
-        auto sDiameter = jmin(localBounds.getWidth(), localBounds.getHeight()) - 4.0f;
+        auto sDiameter = juce::jmin(localBounds.getWidth(), localBounds.getHeight()) - 4.0f;
         auto textBoxWidth  = sDiameter * .66f;
         auto textBoxHeight = sDiameter * .17f;
       
-        Slider::SliderLayout layout;
+        juce::Slider::SliderLayout layout;
 
         // 2. set the textBox bounds
 
-        if (textBoxPos != Slider::NoTextBox)
+        if (textBoxPos != juce::Slider::NoTextBox)
         {
             if (slider.isBar())
             {
@@ -385,12 +407,12 @@ void LookAndFeel::drawFlatButtonBackground (Graphics& g,
                 layout.textBoxBounds.setWidth (textBoxWidth);
                 layout.textBoxBounds.setHeight (textBoxHeight);
 
-                if (textBoxPos == Slider::TextBoxLeft)           layout.textBoxBounds.setX (0);
-                else if (textBoxPos == Slider::TextBoxRight)     layout.textBoxBounds.setX (localBounds.getWidth() - textBoxWidth);
+                if (textBoxPos == juce::Slider::TextBoxLeft)           layout.textBoxBounds.setX (0);
+                else if (textBoxPos == juce::Slider::TextBoxRight)     layout.textBoxBounds.setX (localBounds.getWidth() - textBoxWidth);
                 else /* above or below -> centre horizontally */ layout.textBoxBounds.setX ((localBounds.getWidth() - textBoxWidth) / 2);
 
-                if (textBoxPos == Slider::TextBoxAbove)          layout.textBoxBounds.setY (0);
-                else if (textBoxPos == Slider::TextBoxBelow)     layout.textBoxBounds.setY (localBounds.getHeight() - textBoxHeight);
+                if (textBoxPos == juce::Slider::TextBoxAbove)          layout.textBoxBounds.setY (0);
+                else if (textBoxPos == juce::Slider::TextBoxBelow)     layout.textBoxBounds.setY (localBounds.getHeight() - textBoxHeight);
                 else /* left or right -> centre vertically */    layout.textBoxBounds.setY ((localBounds.getHeight() - textBoxHeight) / 2);
             }
         }
@@ -405,10 +427,10 @@ void LookAndFeel::drawFlatButtonBackground (Graphics& g,
         }
         else
         {
-            if (textBoxPos == Slider::TextBoxLeft)       layout.sliderBounds.removeFromLeft (textBoxWidth);
-            else if (textBoxPos == Slider::TextBoxRight) layout.sliderBounds.removeFromRight (textBoxWidth);
-            else if (textBoxPos == Slider::TextBoxAbove) layout.sliderBounds.removeFromTop (textBoxHeight);
-            else if (textBoxPos == Slider::TextBoxBelow) layout.sliderBounds.removeFromBottom (textBoxHeight);
+            if (textBoxPos == juce::Slider::TextBoxLeft)       layout.sliderBounds.removeFromLeft (textBoxWidth);
+            else if (textBoxPos == juce::Slider::TextBoxRight) layout.sliderBounds.removeFromRight (textBoxWidth);
+            else if (textBoxPos == juce::Slider::TextBoxAbove) layout.sliderBounds.removeFromTop (textBoxHeight);
+            else if (textBoxPos == juce::Slider::TextBoxBelow) layout.sliderBounds.removeFromBottom (textBoxHeight);
 
             const int thumbIndent = getSliderThumbRadius (slider);
 

--- a/libs/Common/GUI/LookAndFeel/LookAndFeel.h
+++ b/libs/Common/GUI/LookAndFeel/LookAndFeel.h
@@ -9,26 +9,28 @@
 */
 
 #pragma once
-#include "JuceHeader.h"
+
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <ff_meters/ff_meters.h>
 
 namespace tote_bag
 {
 class FlatTextButton;
 
-class LookAndFeel : public LookAndFeel_V4,
+class LookAndFeel : public juce::LookAndFeel_V4,
                      public FFAU::LevelMeter::LookAndFeelMethods
 {
     
 public:
     LookAndFeel();
 
-    void drawSliderMeter(Graphics& g,
-                         const Rectangle<float> bounds,
+    void drawSliderMeter(juce::Graphics& g,
+                         const juce::Rectangle<float> bounds,
                          float lineWidth,
                          float arcRadius,
                          float rotaryStartAngle, float rotaryEndAngle,
                          float toAngle,
-                         Slider& slider);
+                         juce::Slider& slider);
     
     /** Draws a drawable knob. Originally used for the knobs in Valentine, this is been refactored
         to not rely on member variables. This, along with the fact that this function isn't called
@@ -37,44 +39,68 @@ public:
 
         TODO: Refactor slider drawing to effectively use this function if desired
      */
-    void drawDrawableKnob(Graphics& g,
+    void drawDrawableKnob(juce::Graphics& g,
                           const float radius,
                           const float drawableWidth,
-                          Drawable& sliderImage,
+                          juce::Drawable& sliderImage,
                           const float toAngle,
-                          const Rectangle<float> bounds);
+                          const juce::Rectangle<float> bounds);
 
-    void drawKnob(Graphics& g,
+    void drawKnob(juce::Graphics& g,
                   const float radius,
                   const float toAngle,
-                  const Rectangle<float> bounds,
-                  Slider& slider,
+                  const juce::Rectangle<float> bounds,
+                  juce::Slider& slider,
                   const bool withDropShadow);
 
-    void drawRotarySlider (Graphics& g, int x, int y, int width, int height, float sliderPos,
-                           const float rotaryStartAngle, const float rotaryEndAngle, Slider&) override;
+    void drawRotarySlider (juce::Graphics& g,
+                           int x, int y,
+                           int width, int height,
+                           float sliderPos,
+                           const float rotaryStartAngle, const float rotaryEndAngle,
+                           juce::Slider&) override;
 
-    Typeface::Ptr getTypefaceForFont (const Font& f) override;
+    juce::Typeface::Ptr getTypefaceForFont (const juce::Font& f) override;
 
-    Font getTextButtonFont (TextButton&, int buttonHeight) override;
-    Font getLabelFont (Label& l) override;
+    juce::Font getTextButtonFont (juce::TextButton&, int buttonHeight) override;
 
-    void drawButtonBackground (Graphics& g, Button& button, const Colour& backgroundColour,
-                          bool, bool isButtonDown) override;
-    void drawFlatButtonBackground (Graphics& g, tote_bag::FlatTextButton& button, const Colour& backgroundColour,
-                          bool, bool isButtonDown);
-    void drawButtonText (Graphics& g, TextButton& button, bool, bool isButtonDown) override;
+    juce::Font getLabelFont (juce::Label& l) override;
+
+    void drawButtonBackground (juce::Graphics& g,
+                               juce::Button& button,
+                               const juce::Colour& backgroundColour,
+                               bool,
+                               bool isButtonDown) override;
     
-    void drawComboBox (Graphics& g, int width, int height, bool, int, int, int, int, ComboBox& box) override;
+    void drawFlatButtonBackground (juce::Graphics& g,
+                                   tote_bag::FlatTextButton& button,
+                                   const juce::Colour& backgroundColour,
+                                   bool,
+                                   bool isButtonDown);
     
-    void drawPopupMenuItem (Graphics& g, const Rectangle<int>& area,
-                                  bool isSeparator, bool isActive, bool isHighlighted, bool isTicked, bool hasSubMenu,
-                                  const String& text, const String& shortcutKeyText,
-                            const Drawable* icon, const Colour* textColour) override;
+    void drawButtonText (juce::Graphics& g,
+                         juce::TextButton& button,
+                         bool,
+                         bool isButtonDown) override;
     
+    void drawComboBox (juce::Graphics& g,
+                       int width, int height,
+                       bool, int, int, int, int,
+                       juce::ComboBox& box) override;
     
+    void drawPopupMenuItem (juce::Graphics& g,
+                            const juce::Rectangle<int>& area,
+                            bool isSeparator,
+                            bool isActive,
+                            bool isHighlighted,
+                            bool isTicked,
+                            bool hasSubMenu,
+                            const juce::String& text,
+                            const juce::String& shortcutKeyText,
+                            const juce::Drawable* icon,
+                            const juce::Colour* textColour) override;
     
-    Slider::SliderLayout getSliderLayout (Slider& slider) override;
+    juce::Slider::SliderLayout getSliderLayout (juce::Slider& slider) override;
     
     enum ColourIds
     {

--- a/libs/Common/GUI/LookAndFeel/LookAndFeelConstants.h
+++ b/libs/Common/GUI/LookAndFeel/LookAndFeelConstants.h
@@ -9,25 +9,26 @@
 */
 
 #pragma once
-#include "JuceHeader.h"
+
+#include <juce_gui_basics/juce_gui_basics.h>
 
 namespace tote_bag
 {
 namespace laf_constants
 {
-const Colour vPink (0xffffc4ee);
-const Colour vPinkDark (0xffe0a2d5);
-const Colour vGreen1 (0xff43a028);
-const Colour vGreen2 (0xff83a028);
-const Colour vRed (0xffef202a);
-const Colour vYellow (0xffffce00);
+const juce::Colour vPink (0xffffc4ee);
+const juce::Colour vPinkDark (0xffe0a2d5);
+const juce::Colour vGreen1 (0xff43a028);
+const juce::Colour vGreen2 (0xff83a028);
+const juce::Colour vRed (0xffef202a);
+const juce::Colour vYellow (0xffffce00);
 
-const Colour vColour_1 = Colour(105,105,105);
-const Colour vColour_2 = Colour(0,0,0).withAlpha(0.0f);
-const Colour vColour_3 = Colour(0,0,0).withAlpha(0.3f);
-const Colour vColour_4 = Colour(0,0,0).withAlpha(0.6f);
-const Colour vColour_5 = Colour(105,105,105).withAlpha(0.3f);
-const Colour vColour_6 = Colour(0,0,0).withAlpha(0.8f);
-const Colour vColour_7 = Colour(125,125,125);
+const juce::Colour vColour_1 = juce::Colour(105,105,105);
+const juce::Colour vColour_2 = juce::Colour(0,0,0).withAlpha(0.0f);
+const juce::Colour vColour_3 = juce::Colour(0,0,0).withAlpha(0.3f);
+const juce::Colour vColour_4 = juce::Colour(0,0,0).withAlpha(0.6f);
+const juce::Colour vColour_5 = juce::Colour(105,105,105).withAlpha(0.3f);
+const juce::Colour vColour_6 = juce::Colour(0,0,0).withAlpha(0.8f);
+const juce::Colour vColour_7 = juce::Colour(125,125,125);
 } // laf_constants
 } // tote_bag

--- a/libs/Common/GUI/Managers/RadioButtonGroupManager.cpp
+++ b/libs/Common/GUI/Managers/RadioButtonGroupManager.cpp
@@ -10,6 +10,8 @@
 
 #include "RadioButtonGroupManager.h"
 
+#include <juce_audio_processors/juce_audio_processors.h>
+
 namespace tote_bag
 {
 

--- a/libs/Common/GUI/Managers/RadioButtonGroupManager.h
+++ b/libs/Common/GUI/Managers/RadioButtonGroupManager.h
@@ -10,7 +10,12 @@
 
 #pragma once
 
-#include <JuceHeader.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+
+namespace juce
+{
+class AudioParameterChoice;
+} // namespace juce
 
 namespace tote_bag
 {

--- a/libs/Common/GUI/Utilities/GraphicsUtilities.cpp
+++ b/libs/Common/GUI/Utilities/GraphicsUtilities.cpp
@@ -30,7 +30,7 @@ void drawRoundedRect(juce::Graphics& g,
 
     g.setColour(colour);
 
-    Path p;
+    juce::Path p;
     p.addRoundedRectangle(croppedBounds, cornerSize);
     g.fillPath(p);
 }

--- a/libs/Common/GUI/Utilities/GraphicsUtilities.h
+++ b/libs/Common/GUI/Utilities/GraphicsUtilities.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include <JuceHeader.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
 namespace gui_utils
 {


### PR DESCRIPTION
JUCE can't create a header for our test target. That, or it is not 
straightforward to do so. Using this header and simply including
into any file using JUCE functionality is somewhat of an anti pattern 
(only include what you use) and has been made optional as of JUCE's
addition of CMake support.

So let's not create the JUCE header and include what we actually need.
...and namespace anything we use. `using namespace juce` is defined
in no longer created header. And it would be more clear to fully qualify
any uses of those methods.