### PR TITLE
Clang format everything

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 # https://forum.juce.com/t/automatic-juce-like-code-formatting-with-clang-format/31624/20
 ---
 AccessModifierOffset: -4
-AlignAfterOpenBracket: DontAlign
+AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
 AlignEscapedNewlines: Left
@@ -33,10 +33,10 @@ BraceWrapping: # Allman except for lambdas
   AfterControlStatement: Always
   BeforeLambdaBody: false
 BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializersBeforeComma: true
 BreakStringLiterals: false
 ColumnLimit: 0
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: false
@@ -51,7 +51,7 @@ KeepEmptyLinesAtTheStartOfBlocks: false
 Language: Cpp
 MaxEmptyLinesToKeep: 1
 FixNamespaceComments: false
-NamespaceIndentation: All
+NamespaceIndentation: None
 PointerAlignment: Left
 ReflowComments: false
 SortIncludes: true

--- a/Source/GUI/Panels/ValentineCenterPanel.cpp
+++ b/Source/GUI/Panels/ValentineCenterPanel.cpp
@@ -9,69 +9,69 @@
 */
 
 #include "ValentineCenterPanel.h"
+#include "BinaryData.h"
 #include "PluginProcessor.h"
 #include "ValentineParameters.h"
-#include "BinaryData.h"
 
-#include "Common/GUI/Utilities/GraphicsUtilities.h"
 #include "Common/GUI/LookAndFeel/LookAndFeel.h"
+#include "Common/GUI/Utilities/GraphicsUtilities.h"
 
 #include <juce_gui_basics/juce_gui_basics.h>
 
 //==============================================================================
 
-CenterPanel::CenterPanel(ValentineAudioProcessor& processor) :
- inputSlider(FFCompParameterID()[getParameterIndex(VParameter::inputGain)], processor.treeState)
-,crushSlider(FFCompParameterID()[getParameterIndex(VParameter::bitCrush)], processor.treeState)
-,saturateSlider(FFCompParameterID()[getParameterIndex(VParameter::saturation)], processor.treeState)
-,ratioSlider(FFCompParameterID()[getParameterIndex(VParameter::ratio)], processor.treeState)
-,attackSlider(FFCompParameterID()[getParameterIndex(VParameter::attack)], processor.treeState)
-,releaseSlider(FFCompParameterID()[getParameterIndex(VParameter::release)], processor.treeState)
-,mixSlider(FFCompParameterID()[getParameterIndex(VParameter::dryWet)], processor.treeState)
-,outputSlider(FFCompParameterID()[getParameterIndex(VParameter::makeupGain)], processor.treeState)
+CenterPanel::CenterPanel (ValentineAudioProcessor& processor)
+    : inputSlider (FFCompParameterID()[getParameterIndex (VParameter::inputGain)], processor.treeState)
+    , crushSlider (FFCompParameterID()[getParameterIndex (VParameter::bitCrush)], processor.treeState)
+    , saturateSlider (FFCompParameterID()[getParameterIndex (VParameter::saturation)], processor.treeState)
+    , ratioSlider (FFCompParameterID()[getParameterIndex (VParameter::ratio)], processor.treeState)
+    , attackSlider (FFCompParameterID()[getParameterIndex (VParameter::attack)], processor.treeState)
+    , releaseSlider (FFCompParameterID()[getParameterIndex (VParameter::release)], processor.treeState)
+    , mixSlider (FFCompParameterID()[getParameterIndex (VParameter::dryWet)], processor.treeState)
+    , outputSlider (FFCompParameterID()[getParameterIndex (VParameter::makeupGain)], processor.treeState)
 {
     // Top left sliders
-    addAndMakeVisible(inputSlider);
-    addAndMakeVisible(crushSlider);
-    addAndMakeVisible(saturateSlider);
+    addAndMakeVisible (inputSlider);
+    addAndMakeVisible (crushSlider);
+    addAndMakeVisible (saturateSlider);
 
     // Bottom left sliders
-    addAndMakeVisible(ratioSlider);
-    addAndMakeVisible(attackSlider);
-    addAndMakeVisible(releaseSlider);
+    addAndMakeVisible (ratioSlider);
+    addAndMakeVisible (attackSlider);
+    addAndMakeVisible (releaseSlider);
 
     // Top right sliders
-    addAndMakeVisible(mixSlider);
-    addAndMakeVisible(outputSlider);
+    addAndMakeVisible (mixSlider);
+    addAndMakeVisible (outputSlider);
 
     // Logo
-    vLogo = juce::Drawable::createFromImageData(BinaryData::logo_218x40_svg,
-                                          BinaryData::logo_218x40_svgSize); 
-    addAndMakeVisible(vLogo.get());
+    vLogo = juce::Drawable::createFromImageData (BinaryData::logo_218x40_svg,
+                                                 BinaryData::logo_218x40_svgSize);
+    addAndMakeVisible (vLogo.get());
 
     // Version label
-    versionLabel.setText(JucePlugin_VersionString, juce::dontSendNotification);
-    versionLabel.setColour(juce::Label::ColourIds::textColourId,
-                           tote_bag::laf_constants::vPinkDark);
-    versionLabel.setJustificationType(juce::Justification::centredTop);
-    addAndMakeVisible(versionLabel);
+    versionLabel.setText (JucePlugin_VersionString, juce::dontSendNotification);
+    versionLabel.setColour (juce::Label::ColourIds::textColourId,
+                            tote_bag::laf_constants::vPinkDark);
+    versionLabel.setJustificationType (juce::Justification::centredTop);
+    addAndMakeVisible (versionLabel);
 
     // Ratio box
-    if (auto ratioParam = dynamic_cast<juce::AudioParameterChoice*>(processor.treeState.getParameter(FFCompParameterID()[getParameterIndex(VParameter::ratio)])))
+    if (auto ratioParam = dynamic_cast<juce::AudioParameterChoice*> (processor.treeState.getParameter (FFCompParameterID()[getParameterIndex (VParameter::ratio)])))
     {
-        mRatioBox = std::make_unique<tote_bag::FlatTextChooser>(FFCompParameterLabel()[getParameterIndex(VParameter::ratio)],
-                                                                std::vector<std::string>{
-                                                                k4_1RatioLabel.data(),
-                                                                k8_1RatioLabel.data(),
-                                                                k12_1RatioLabel.data(),
-                                                                k20_1RatioLabel.data(),
-                                                                k1000_1RatioLabel.data()},
-                                                                8001,
-                                                                ratioParam,
-                                                                true);
+        mRatioBox = std::make_unique<tote_bag::FlatTextChooser> (FFCompParameterLabel()[getParameterIndex (VParameter::ratio)],
+                                                                 std::vector<std::string> {
+                                                                     k4_1RatioLabel.data(),
+                                                                     k8_1RatioLabel.data(),
+                                                                     k12_1RatioLabel.data(),
+                                                                     k20_1RatioLabel.data(),
+                                                                     k1000_1RatioLabel.data() },
+                                                                 8001,
+                                                                 ratioParam,
+                                                                 true);
     }
 
-    addAndMakeVisible(mRatioBox.get());
+    addAndMakeVisible (mRatioBox.get());
 }
 
 CenterPanel::~CenterPanel()
@@ -82,40 +82,40 @@ void CenterPanel::paint (juce::Graphics& g)
 {
     using namespace tote_bag::laf_constants;
 
-    gui_utils::drawRoundedRect(g, topLeftRowBorderBounds.toFloat(), vPinkDark);
-    gui_utils::drawRoundedRect(g, bottomLeftRowBorderBounds.toFloat(), vPinkDark);
-    gui_utils::drawRoundedRect(g, topRightRowBorderBounds.toFloat(), vPinkDark);
+    gui_utils::drawRoundedRect (g, topLeftRowBorderBounds.toFloat(), vPinkDark);
+    gui_utils::drawRoundedRect (g, bottomLeftRowBorderBounds.toFloat(), vPinkDark);
+    gui_utils::drawRoundedRect (g, topRightRowBorderBounds.toFloat(), vPinkDark);
 }
 
 void CenterPanel::resized()
 {
     auto workingArea = getLocalBounds();
 
-    auto areaFunc = [](juce::Rectangle<int>& area, int numSliders, int sliderCount) -> juce::Rectangle<int> {
+    auto areaFunc = [] (juce::Rectangle<int>& area, int numSliders, int sliderCount) -> juce::Rectangle<int> {
         return area.removeFromLeft (area.getWidth() / (numSliders - sliderCount));
     };
 
-    const auto paramWidth = juce::roundToInt(workingArea.getWidth() / 5.0f);
+    const auto paramWidth = juce::roundToInt (workingArea.getWidth() / 5.0f);
 
     // Center slider rows vertically
     auto betweenRowMargin = paramWidth * .1f;
 
     // 1.65 to reflect that the bottom half is .65 the height of the top row
     auto totalParamHeight = (paramWidth * 1.65f) + betweenRowMargin;
-    auto verticalAlignmentSpacer = juce::roundToInt((workingArea.getHeight() - totalParamHeight) * .5f);
-    workingArea.removeFromTop(verticalAlignmentSpacer);
-    workingArea.removeFromBottom(verticalAlignmentSpacer);
+    auto verticalAlignmentSpacer = juce::roundToInt ((workingArea.getHeight() - totalParamHeight) * .5f);
+    workingArea.removeFromTop (verticalAlignmentSpacer);
+    workingArea.removeFromBottom (verticalAlignmentSpacer);
 
     const auto borderMargin = paramWidth * .05f;
 
     // Left side
     const auto numLeftColumns = 3;
-    auto leftSideBounds = workingArea.removeFromLeft(paramWidth * numLeftColumns);
+    auto leftSideBounds = workingArea.removeFromLeft (paramWidth * numLeftColumns);
 
     // Top
-    topLeftRowBorderBounds = leftSideBounds.removeFromTop(paramWidth);
+    topLeftRowBorderBounds = leftSideBounds.removeFromTop (paramWidth);
 
-    auto topLeftRowBounds = topLeftRowBorderBounds.reduced(borderMargin);
+    auto topLeftRowBounds = topLeftRowBorderBounds.reduced (borderMargin);
 
     std::array<LabelSlider*, numLeftColumns> topLeftRowComponents = {
         &inputSlider,
@@ -125,21 +125,21 @@ void CenterPanel::resized()
 
     for (int i = 0; i < numLeftColumns; ++i)
     {
-        topLeftRowComponents[i]->setBounds(areaFunc(topLeftRowBounds, numLeftColumns, i));
+        topLeftRowComponents[i]->setBounds (areaFunc (topLeftRowBounds, numLeftColumns, i));
     }
 
     // Margin
-    leftSideBounds.removeFromTop(betweenRowMargin);
+    leftSideBounds.removeFromTop (betweenRowMargin);
 
     // Bottom
-    auto bottomRowParamHeight = juce::roundToInt(paramWidth * .65f);
+    auto bottomRowParamHeight = juce::roundToInt (paramWidth * .65f);
     const auto smallborderMargin = bottomRowParamHeight * .05f;
-    bottomLeftRowBorderBounds = leftSideBounds.removeFromTop(bottomRowParamHeight);
+    bottomLeftRowBorderBounds = leftSideBounds.removeFromTop (bottomRowParamHeight);
 
-    auto bottomLeftRowBounds = bottomLeftRowBorderBounds.reduced(smallborderMargin);
+    auto bottomLeftRowBounds = bottomLeftRowBorderBounds.reduced (smallborderMargin);
 
-    auto ratioBounds = bottomLeftRowBounds.removeFromLeft(bottomLeftRowBounds.getWidth() / 3.0f);
-    mRatioBox->setBounds(ratioBounds);
+    auto ratioBounds = bottomLeftRowBounds.removeFromLeft (bottomLeftRowBounds.getWidth() / 3.0f);
+    mRatioBox->setBounds (ratioBounds);
 
     const auto numBottomLeftColumns = numLeftColumns - 1;
 
@@ -150,19 +150,19 @@ void CenterPanel::resized()
 
     for (int i = 0; i < numBottomLeftColumns; ++i)
     {
-        bottomLeftRowComponents[i]->setBounds(areaFunc(bottomLeftRowBounds, numBottomLeftColumns, i));
+        bottomLeftRowComponents[i]->setBounds (areaFunc (bottomLeftRowBounds, numBottomLeftColumns, i));
     }
 
     // Vertical margin
-    workingArea.removeFromLeft(betweenRowMargin);
+    workingArea.removeFromLeft (betweenRowMargin);
 
     const auto numRightColumns = 2;
-    auto rightSideBounds = workingArea.removeFromLeft(paramWidth * numRightColumns);
+    auto rightSideBounds = workingArea.removeFromLeft (paramWidth * numRightColumns);
 
     // Top right
-    topRightRowBorderBounds = rightSideBounds.removeFromTop(paramWidth);
+    topRightRowBorderBounds = rightSideBounds.removeFromTop (paramWidth);
 
-    auto topRightRowBounds = topRightRowBorderBounds.reduced(borderMargin);
+    auto topRightRowBounds = topRightRowBorderBounds.reduced (borderMargin);
 
     std::array<LabelSlider*, numRightColumns> topRightRowComponents = {
         &outputSlider,
@@ -171,20 +171,19 @@ void CenterPanel::resized()
 
     for (int i = 0; i < numRightColumns; ++i)
     {
-        topRightRowComponents[i]->setBounds(areaFunc(topRightRowBounds, numRightColumns, i));
+        topRightRowComponents[i]->setBounds (areaFunc (topRightRowBounds, numRightColumns, i));
     }
 
     // Margin
-    rightSideBounds.removeFromTop(betweenRowMargin);
+    rightSideBounds.removeFromTop (betweenRowMargin);
 
     // Bottom right
-    auto logoHeight = juce::roundToInt(paramWidth * .5f);
-    auto versionHeight = juce::roundToInt(logoHeight * .25);
+    auto logoHeight = juce::roundToInt (paramWidth * .5f);
+    auto versionHeight = juce::roundToInt (logoHeight * .25);
 
-    auto logoBounds = rightSideBounds.removeFromTop(logoHeight).removeFromLeft(paramWidth * numRightColumns).reduced(borderMargin);
-    auto versionBounds = logoBounds.removeFromBottom(versionHeight);
+    auto logoBounds = rightSideBounds.removeFromTop (logoHeight).removeFromLeft (paramWidth * numRightColumns).reduced (borderMargin);
+    auto versionBounds = logoBounds.removeFromBottom (versionHeight);
 
-    vLogo->setTransformToFit(logoBounds.toFloat(), juce::RectanglePlacement(juce::RectanglePlacement::xMid |
-                                                                            juce::RectanglePlacement::yTop));
-    versionLabel.setBounds(versionBounds);
+    vLogo->setTransformToFit (logoBounds.toFloat(), juce::RectanglePlacement (juce::RectanglePlacement::xMid | juce::RectanglePlacement::yTop));
+    versionLabel.setBounds (versionBounds);
 }

--- a/Source/GUI/Panels/ValentineCenterPanel.h
+++ b/Source/GUI/Panels/ValentineCenterPanel.h
@@ -10,9 +10,9 @@
 
 #pragma once
 
+#include "Common/GUI/Components/Widgets/FlatTextChooser.h"
 #include "Common/GUI/Components/Widgets/LabelSlider.h"
 #include "Common/GUI/LookAndFeel/LookAndFeelConstants.h"
-#include "Common/GUI/Components/Widgets/FlatTextChooser.h"
 
 #include <juce_gui_basics/juce_gui_basics.h>
 
@@ -22,10 +22,10 @@
 
 class ValentineAudioProcessor;
 
-class CenterPanel  : public juce::Component
+class CenterPanel : public juce::Component
 {
 public:
-    CenterPanel(ValentineAudioProcessor& processor);
+    CenterPanel (ValentineAudioProcessor& processor);
     ~CenterPanel() override;
 
     void paint (juce::Graphics&) override;

--- a/Source/GUI/Panels/ValentineMainPanel.cpp
+++ b/Source/GUI/Panels/ValentineMainPanel.cpp
@@ -9,65 +9,64 @@
 */
 
 #include "ValentineMainPanel.h"
-#include "ValentineParameters.h"
 #include "PluginProcessor.h"
+#include "ValentineParameters.h"
 
 #include "Common/GUI/LookAndFeel/LookAndFeelConstants.h"
 
-
-VMainPanel::VMainPanel(ValentineAudioProcessor& processor) :
- presetPanel(processor.getPresetManager(),
-             FFCompParameterLabel()[getParameterIndex(VParameter::bypass)],
-             FFCompParameterID()[getParameterIndex(VParameter::bypass)],
-             processor.treeState)
-,inputMeterPanel("In",
-                 ReductionMeterPlacement::Right,
-                 &processor.getInputMeterSource())
-,outputMeterPanel("Out",
-                  ReductionMeterPlacement::Left,
-                  &processor.getOutputMeterSource(),
-                  &processor.getGrMeterSource())
-,centerPanel(processor)
+VMainPanel::VMainPanel (ValentineAudioProcessor& processor)
+    : presetPanel (processor.getPresetManager(),
+                   FFCompParameterLabel()[getParameterIndex (VParameter::bypass)],
+                   FFCompParameterID()[getParameterIndex (VParameter::bypass)],
+                   processor.treeState)
+    , inputMeterPanel ("In",
+                       ReductionMeterPlacement::Right,
+                       &processor.getInputMeterSource())
+    , outputMeterPanel ("Out",
+                        ReductionMeterPlacement::Left,
+                        &processor.getOutputMeterSource(),
+                        &processor.getGrMeterSource())
+    , centerPanel (processor)
 {
-    setLookAndFeel(&lookAndFeel);
+    setLookAndFeel (&lookAndFeel);
 
-    addAndMakeVisible(presetPanel);
-    addAndMakeVisible(centerPanel);
-    addAndMakeVisible(inputMeterPanel);
-    addAndMakeVisible(outputMeterPanel);
+    addAndMakeVisible (presetPanel);
+    addAndMakeVisible (centerPanel);
+    addAndMakeVisible (inputMeterPanel);
+    addAndMakeVisible (outputMeterPanel);
 }
 
 VMainPanel::~VMainPanel()
 {
-    setLookAndFeel(nullptr);
+    setLookAndFeel (nullptr);
 }
 
-void VMainPanel::paint(juce::Graphics& g)
+void VMainPanel::paint (juce::Graphics& g)
 {
-    g.fillAll(tote_bag::laf_constants::vPink);
+    g.fillAll (tote_bag::laf_constants::vPink);
 }
 
 void VMainPanel::resized()
 {
     auto panelBounds = getLocalBounds();
 
-    const auto presetBounds = panelBounds.removeFromTop(juce::roundToInt(panelBounds.getHeight() * .075f));
-    presetPanel.setBounds(presetBounds);
+    const auto presetBounds = panelBounds.removeFromTop (juce::roundToInt (panelBounds.getHeight() * .075f));
+    presetPanel.setBounds (presetBounds);
 
-    const auto resizerMargin = juce::roundToInt(panelBounds.getHeight() * .03f);
-    panelBounds.removeFromLeft(resizerMargin);
-    panelBounds.removeFromRight(resizerMargin);
-    panelBounds.removeFromBottom(resizerMargin);
-    panelBounds.removeFromTop(juce::roundToInt(resizerMargin * .5));
+    const auto resizerMargin = juce::roundToInt (panelBounds.getHeight() * .03f);
+    panelBounds.removeFromLeft (resizerMargin);
+    panelBounds.removeFromRight (resizerMargin);
+    panelBounds.removeFromBottom (resizerMargin);
+    panelBounds.removeFromTop (juce::roundToInt (resizerMargin * .5));
 
-    const auto meterWidth = juce::roundToInt(panelBounds.getWidth() * .05f);
-    const auto outMeterBounds = panelBounds.removeFromRight(meterWidth);
-    const auto inMeterBounds = panelBounds.removeFromLeft(meterWidth);
+    const auto meterWidth = juce::roundToInt (panelBounds.getWidth() * .05f);
+    const auto outMeterBounds = panelBounds.removeFromRight (meterWidth);
+    const auto inMeterBounds = panelBounds.removeFromLeft (meterWidth);
 
     // Shift working area left to account for wider output meter
-    panelBounds.removeFromRight(juce::roundToInt(meterWidth / 4.f));
+    panelBounds.removeFromRight (juce::roundToInt (meterWidth / 4.f));
 
-    inputMeterPanel.setBounds(inMeterBounds);
-    outputMeterPanel.setBounds(outMeterBounds);
-    centerPanel.setBounds(panelBounds);
+    inputMeterPanel.setBounds (inMeterBounds);
+    outputMeterPanel.setBounds (outMeterBounds);
+    centerPanel.setBounds (panelBounds);
 }

--- a/Source/GUI/Panels/ValentineMainPanel.h
+++ b/Source/GUI/Panels/ValentineMainPanel.h
@@ -12,9 +12,9 @@
 
 #include "ValentineCenterPanel.h"
 
-#include "Common/GUI/LookAndFeel/LookAndFeel.h"
 #include "Common/GUI/Components/Panels/PresetPanel.h"
 #include "Common/GUI/Components/Panels/VerticalMeterPanel.h"
+#include "Common/GUI/LookAndFeel/LookAndFeel.h"
 
 #include <juce_gui_basics/juce_gui_basics.h>
 
@@ -23,12 +23,13 @@ class ValentineAudioProcessor;
 class VMainPanel : public juce::Component
 {
 public:
-    VMainPanel(ValentineAudioProcessor& inProcessor);
+    VMainPanel (ValentineAudioProcessor& inProcessor);
     ~VMainPanel();
 
     void paint (juce::Graphics& g) override;
 
     void resized() override;
+
 private:
     tote_bag::LookAndFeel lookAndFeel;
 

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -8,15 +8,15 @@
   ==============================================================================
 */
 
-#include "PluginProcessor.h"
 #include "PluginEditor.h"
 #include "../Source/ValentineParameters.h"
+#include "PluginProcessor.h"
 //==============================================================================
 ValentineAudioProcessorEditor::ValentineAudioProcessorEditor (ValentineAudioProcessor& p)
-    : AudioProcessorEditor (&p), processor (p)
+    : AudioProcessorEditor (&p)
+    , processor (p)
 {
-
-    addAndMakeVisible(mainPanel);
+    addAndMakeVisible (mainPanel);
 
     auto w = 0.0f;
 
@@ -25,15 +25,14 @@ ValentineAudioProcessorEditor::ValentineAudioProcessorEditor (ValentineAudioProc
     else
         w = startingWidth;
 
-    setResizable(true, true);
+    setResizable (true, true);
     setResizeLimits (minimumWidth,
                      minimumWidth / ratio,
                      maximumWidth,
                      maximumWidth / ratio);
-    getConstrainer()->setFixedAspectRatio(ratio);
+    getConstrainer()->setFixedAspectRatio (ratio);
 
-    setSize(w, w / ratio);
-
+    setSize (w, w / ratio);
 }
 
 ValentineAudioProcessorEditor::~ValentineAudioProcessorEditor()
@@ -48,7 +47,5 @@ void ValentineAudioProcessorEditor::paint (juce::Graphics& g)
 
 void ValentineAudioProcessorEditor::resized()
 {
-    mainPanel.setBounds(getLocalBounds());
+    mainPanel.setBounds (getLocalBounds());
 }
-
-

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -17,10 +17,9 @@
 #include <juce_audio_processors/juce_audio_processors.h>
 #include <juce_gui_basics/juce_gui_basics.h>
 
-
 //==============================================================================
 
-class ValentineAudioProcessorEditor  : public juce::AudioProcessorEditor
+class ValentineAudioProcessorEditor : public juce::AudioProcessorEditor
 {
 public:
     ValentineAudioProcessorEditor (ValentineAudioProcessor&);
@@ -35,7 +34,7 @@ private:
     // access the processor object that created it.
     ValentineAudioProcessor& processor;
 
-    VMainPanel mainPanel {processor};
+    VMainPanel mainPanel { processor };
 
     // in figma ~ 5053 x 1741. ratio = 2.9 ish width to height
     static constexpr float ratio = 2.5f;

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -12,11 +12,11 @@
 
 #include "ValentineParameters.h"
 
-#include "Common/DSP/Compressor.h"
-#include "Common/DSP/Saturation.h"
-#include "Common/DSP/DigiDegraders.h"
-#include "Common/DSP/ThiranAllpass.h"
 #include "Common/DSP/CircularBuffer.h"
+#include "Common/DSP/Compressor.h"
+#include "Common/DSP/DigiDegraders.h"
+#include "Common/DSP/Saturation.h"
+#include "Common/DSP/ThiranAllpass.h"
 #include "Common/GUI/Managers/ToteBagPresetManager.h"
 
 #include <juce_audio_processors/juce_audio_processors.h>
@@ -25,8 +25,8 @@
 /**
 */
 
-class ValentineAudioProcessor  :    public juce::AudioProcessor,
-                                    public juce::AudioProcessorValueTreeState::Listener
+class ValentineAudioProcessor : public juce::AudioProcessor,
+                                public juce::AudioProcessorValueTreeState::Listener
 {
 public:
     //==============================================================================
@@ -37,9 +37,9 @@ public:
     void prepareToPlay (double sampleRate, int samplesPerBlock) override;
     void releaseResources() override;
 
-   #ifndef JucePlugin_PreferredChannelConfigurations
+#ifndef JucePlugin_PreferredChannelConfigurations
     bool isBusesLayoutSupported (const BusesLayout& layouts) const override;
-   #endif
+#endif
 
     void processBlock (juce::AudioBuffer<float>&, juce::MidiBuffer&) override;
     void processBlockBypassed (juce::AudioBuffer<float>&, juce::MidiBuffer&) override;
@@ -65,7 +65,7 @@ public:
 
     //==============================================================================
     void parameterChanged (const juce::String& parameter, float newValue) override;
-    void initializeParams(double sampleRate);
+    void initializeParams (double sampleRate);
     void getStateInformation (juce::MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
     void initializeDSP();
@@ -82,22 +82,21 @@ public:
     /** Returns the saved GUI width. Used by Editor to decide what dimesions
         to use during construction.
      */
-    const int getSavedGUIwidth () {return savedWidth.get();}
+    const int getSavedGUIwidth() { return savedWidth.get(); }
 
-    FFAU::LevelMeterSource& getInputMeterSource() {return inputMeterSource;}
-    FFAU::LevelMeterSource& getOutputMeterSource() {return outputMeterSource;}
-    FFAU::LevelMeterSource& getGrMeterSource() {return grMeterSource;}
+    FFAU::LevelMeterSource& getInputMeterSource() { return inputMeterSource; }
+    FFAU::LevelMeterSource& getOutputMeterSource() { return outputMeterSource; }
+    FFAU::LevelMeterSource& getGrMeterSource() { return grMeterSource; }
 
     /** Called in Editor destructor to save the gui width
      */
-    void saveGUIwidth (const int w) {savedWidth.set(w);}
+    void saveGUIwidth (const int w) { savedWidth.set (w); }
 
     juce::AudioProcessorValueTreeState treeState;
 
-    ToteBagPresetManager& getPresetManager() {return presetManager;}
+    ToteBagPresetManager& getPresetManager() { return presetManager; }
 
 private:
-
     ToteBagPresetManager presetManager;
 
     FFAU::LevelMeterSource inputMeterSource;
@@ -110,45 +109,45 @@ private:
 
     using Oversampling = juce::dsp::Oversampling<float>;
 
-    const int oversampleFactor {2};
-    int circBuffDelay{-1};
+    const int oversampleFactor { 2 };
+    int circBuffDelay { -1 };
 
-    const float boundedSatGain {1.0f},
-                downSampleRate {27500.0f},
-                RMStime {50.0f};
+    const float boundedSatGain { 1.0f },
+        downSampleRate { 27500.0f },
+        RMStime { 50.0f };
 
     // drop gain before processing...maybe
-    const float internalBias {juce::Decibels::decibelsToGain(-9.f)};
-    const float invInternalBias {1.0f / internalBias};
+    const float internalBias { juce::Decibels::decibelsToGain (-9.f) };
+    const float invInternalBias { 1.0f / internalBias };
 
     juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> dryWet;
 
-    const double dryWetRampLength {.10}; // in seconds, used in .reset()
+    const double dryWetRampLength { .10 }; // in seconds, used in .reset()
 
     // used to index into ratio array
     int ratioIndex = 0;
 
     // used to maintain state for ApplyGainRamp
     // compress and makeup are addressed in dB, interface-wise, but handled linearly here
-    float smoothedGain {1.0f},
-          currentGain {juce::Decibels::decibelsToGain(FFCompParameterDefaults[getParameterIndex(VParameter::inputGain)])},
-          currentMakeup {juce::Decibels::decibelsToGain(FFCompParameterDefaults[getParameterIndex(VParameter::makeupGain)])},
-          currentNiceGain {1.0f};
+    float smoothedGain { 1.0f },
+        currentGain { juce::Decibels::decibelsToGain (FFCompParameterDefaults[getParameterIndex (VParameter::inputGain)]) },
+        currentMakeup { juce::Decibels::decibelsToGain (FFCompParameterDefaults[getParameterIndex (VParameter::makeupGain)]) },
+        currentNiceGain { 1.0f };
 
     // compress and makeup are addressed in dB, interface-wise, but handled linearly here
-    juce::Atomic<float> compressValue {juce::Decibels::decibelsToGain(FFCompParameterDefaults[getParameterIndex(VParameter::inputGain)])},
-                  mixValue {1.0f},
-                  makeupValue {juce::Decibels::decibelsToGain(FFCompParameterDefaults[getParameterIndex(VParameter::makeupGain)])},
-                  currentWidth {0.0f},
-                  currentHeight {0.0f},
-                  newNiceGain {1.0f},
-                  newNiceInvGain {1.0f};
+    juce::Atomic<float> compressValue { juce::Decibels::decibelsToGain (FFCompParameterDefaults[getParameterIndex (VParameter::inputGain)]) },
+        mixValue { 1.0f },
+        makeupValue { juce::Decibels::decibelsToGain (FFCompParameterDefaults[getParameterIndex (VParameter::makeupGain)]) },
+        currentWidth { 0.0f },
+        currentHeight { 0.0f },
+        newNiceGain { 1.0f },
+        newNiceInvGain { 1.0f };
 
-    juce::Atomic<int> savedWidth {0};
+    juce::Atomic<int> savedWidth { 0 };
 
-    juce::Atomic<bool> crushOn {false};
-    juce::Atomic<bool> niceModeOn {false};
-    juce::Atomic<bool> bypassOn{false};
+    juce::Atomic<bool> crushOn { false };
+    juce::Atomic<bool> niceModeOn { false };
+    juce::Atomic<bool> bypassOn { false };
 
     // This is used for, yes you guessed it, processing
     juce::AudioBuffer<float> processBuffer;
@@ -168,4 +167,3 @@ private:
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ValentineAudioProcessor)
 };
-

--- a/Source/ValentineParameters.h
+++ b/Source/ValentineParameters.h
@@ -14,11 +14,9 @@
 
 #include <juce_core/juce_core.h>
 
-
 constexpr int ValentineParameterVersion = 1;
 
-enum class VParameter
-{
+enum class VParameter {
     inputGain = 0,
     bitCrush,
     saturation,
@@ -34,18 +32,17 @@ enum class VParameter
 
 namespace
 {
-const size_t getParameterIndex(VParameter param)
+const size_t getParameterIndex (VParameter param)
 {
-    return static_cast<size_t>(param);
+    return static_cast<size_t> (param);
 }
 } // namespace
 
-static constexpr auto numParams = static_cast<int>(VParameter::TOTAL_NUM_PARAMETERS);
+static constexpr auto numParams = static_cast<int> (VParameter::TOTAL_NUM_PARAMETERS);
 
 inline const std::array<juce::String, numParams>& FFCompParameterID()
 {
-    static const std::array<juce::String, numParams> parameterIDs =
-    {
+    static const std::array<juce::String, numParams> parameterIDs = {
         "Compress",
         "Crush",
         "Saturation",
@@ -57,14 +54,13 @@ inline const std::array<juce::String, numParams>& FFCompParameterID()
         "Nice",
         "Bypass"
     };
-    
+
     return parameterIDs;
 }
 
 inline const std::array<juce::String, numParams>& FFCompParameterLabel()
 {
-    static const std::array<juce::String, numParams> parameterLabels =
-    {
+    static const std::array<juce::String, numParams> parameterLabels = {
         "Input",
         "Crush",
         "Saturation",
@@ -76,14 +72,13 @@ inline const std::array<juce::String, numParams>& FFCompParameterLabel()
         "Nice",
         "Bypass"
     };
-    
+
     return parameterLabels;
 }
 
 inline const std::array<juce::String, numParams>& VParameterUnit()
 {
-    static const std::array<juce::String, numParams> unitLabels =
-    {
+    static const std::array<juce::String, numParams> unitLabels = {
         " dB",
         " %",
         " %",
@@ -95,7 +90,7 @@ inline const std::array<juce::String, numParams>& VParameterUnit()
         "",
         ""
     };
-    
+
     return unitLabels;
 }
 
@@ -110,8 +105,7 @@ constexpr std::string_view k1000_1RatioLabel = "∞";
 
 }
 
-static constexpr std::array<float, numParams> FFCompParameterMin =
-{
+static constexpr std::array<float, numParams> FFCompParameterMin = {
     -24.0f,
     0.0f,
     0.0f,
@@ -124,8 +118,7 @@ static constexpr std::array<float, numParams> FFCompParameterMin =
     0.0f
 };
 
-static constexpr std::array<float, numParams> FFCompParameterMax =
-{
+static constexpr std::array<float, numParams> FFCompParameterMax = {
     48.0f,
     100.0f,
     100.0f,
@@ -138,8 +131,7 @@ static constexpr std::array<float, numParams> FFCompParameterMax =
     1.0f
 };
 
-static constexpr std::array<float, numParams> FFCompParameterDefaults =
-{
+static constexpr std::array<float, numParams> FFCompParameterDefaults = {
     0.0f,
     0.0f,
     0.0f,
@@ -152,8 +144,7 @@ static constexpr std::array<float, numParams> FFCompParameterDefaults =
     0.0f
 };
 
-static constexpr std::array<float, numParams> FFCompParameterIncrement =
-{
+static constexpr std::array<float, numParams> FFCompParameterIncrement = {
     0.00001f,
     0.00001f,
     0.00001f,
@@ -166,8 +157,7 @@ static constexpr std::array<float, numParams> FFCompParameterIncrement =
     1.0f
 };
 
-static constexpr std::array<float, numParams> FFCompParamCenter =
-{
+static constexpr std::array<float, numParams> FFCompParamCenter = {
     23.0f,
     60.0f,
     60.0f,
@@ -180,8 +170,7 @@ static constexpr std::array<float, numParams> FFCompParamCenter =
     0.5f
 };
 
-static constexpr std::array<int, numParams> VParamPrecision =
-{
+static constexpr std::array<int, numParams> VParamPrecision = {
     2,
     2,
     2,
@@ -196,8 +185,7 @@ static constexpr std::array<int, numParams> VParamPrecision =
 
 //==================================================================================
 
-static constexpr std::array<int, 5> ratioValues =
-{
+static constexpr std::array<int, 5> ratioValues = {
     4,
     8,
     12,
@@ -205,8 +193,7 @@ static constexpr std::array<int, 5> ratioValues =
     1000,
 };
 
-static constexpr std::array<float, 5> kneeValues =
-{
+static constexpr std::array<float, 5> kneeValues = {
     6.0f,
     3.84f,
     2.16f,
@@ -214,9 +201,7 @@ static constexpr std::array<float, 5> kneeValues =
     0.0f,
 };
 
-
-static constexpr std::array<float, 5> thresholdValues =
-{
+static constexpr std::array<float, 5> thresholdValues = {
     -18.0f,
     -14.0f,
     -13.0f,

--- a/Tests/PluginBasics.cpp
+++ b/Tests/PluginBasics.cpp
@@ -2,9 +2,9 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 
-TEST_CASE("one is equal to one", "[dummy]")
+TEST_CASE ("one is equal to one", "[dummy]")
 {
-  REQUIRE(1 == 1);
+    REQUIRE (1 == 1);
 }
 
 // https://github.com/McMartin/FRUT/issues/490#issuecomment-663544272

--- a/libs/Common/DSP/AudioHelpers.h
+++ b/libs/Common/DSP/AudioHelpers.h
@@ -25,7 +25,7 @@ inline float linearInterp (float x1, float x2, float frac)
 template <typename T>
 inline void checkUnderflow (T& x)
 {
-    if(abs(x) < std::numeric_limits<T>::epsilon())
+    if (abs (x) < std::numeric_limits<T>::epsilon())
         x = 0.0f;
 }
 
@@ -34,42 +34,41 @@ class SimpleOnePole
 {
 public:
     void reset() { prevValue = 0.0; }
-    
-    void prepare(T newCoeff){ coeff = newCoeff; }
-   
-    T processSample(T inputSample)
+
+    void prepare (T newCoeff) { coeff = newCoeff; }
+
+    T processSample (T inputSample)
     {
         // whoops! looks like you forgot to set the coefficient
-        assert(coeff != -1);
-        
+        assert (coeff != -1);
+
         auto output = coeff * (prevValue - inputSample) + inputSample;
         prevValue = output;
         return output;
     }
-  
+
 private:
     T prevValue, coeff = -1;
-    
 };
 
 template <typename FloatType>
 FloatType max (FloatType x, FloatType y)
 {
-   x -= y;
-   x += abs(x);
-   x *= 0.5;
-   x += y;
-   return (x);
+    x -= y;
+    x += abs (x);
+    x *= 0.5;
+    x += y;
+    return (x);
 }
 
 template <typename FloatType>
 FloatType min (FloatType x, FloatType y)
 {
     x = y - x;
-    x += abs(x);
+    x += abs (x);
     x *= 0.5;
     x = y - x;
-   return (x);
+    return (x);
 }
 
 /** a fast clipping algorithm source: https://www.musicdsp.org/en/latest/Other/81-clipping-without-branching.html
@@ -78,12 +77,12 @@ FloatType min (FloatType x, FloatType y)
 template <typename FloatType>
 FloatType fastClip (FloatType x, FloatType minimumValue, FloatType maximumValue)
 {
-   const FloatType x1 = abs(x - minimumValue);
-   const FloatType x2 = abs(x - maximumValue);
-   x = x1 + (minimumValue + maximumValue);
-   x -= x2;
-   x *= 0.5;
-   return (x);
+    const FloatType x1 = abs (x - minimumValue);
+    const FloatType x2 = abs (x - maximumValue);
+    x = x1 + (minimumValue + maximumValue);
+    x -= x2;
+    x *= 0.5;
+    return (x);
 }
 
 /** Returns cosh(x), clamping input beforehand to prevent overflow.
@@ -94,12 +93,12 @@ FloatType fastClip (FloatType x, FloatType minimumValue, FloatType maximumValue)
     if aliasing becomes an issue.
  */
 template <typename FloatType>
-inline FloatType ClampedCosh(FloatType x)
+inline FloatType ClampedCosh (FloatType x)
 {
     static constexpr FloatType coshMin = -710.0;
     static constexpr FloatType coshMax = 710.0;
 
-    return std::cosh(std::clamp(x, coshMin, coshMax));
+    return std::cosh (std::clamp (x, coshMin, coshMax));
 }
 
 } // namespace audio_helpers

--- a/libs/Common/DSP/CircularBuffer.h
+++ b/libs/Common/DSP/CircularBuffer.h
@@ -17,27 +17,27 @@ class CircularBuffer
 {
 public:
     CircularBuffer() {}
-    
+
     void reset()
     {
         writeIndex = 0;
         buffer.clear();
     }
-    
-    int findNextPow2(int bufferLength)
+
+    int findNextPow2 (int bufferLength)
     {
-        return static_cast<int>((std::pow(2, std::ceil(std::log(bufferLength) / std::log(2)))));
+        return static_cast<int> ((std::pow (2, std::ceil (std::log (bufferLength) / std::log (2)))));
     }
-    
-    void setSize(int inBufferLength)
+
+    void setSize (int inBufferLength)
     {
-        bufferLength = findNextPow2(inBufferLength);
+        bufferLength = findNextPow2 (inBufferLength);
         wrapMask = bufferLength - 1;
-        buffer.setSize(1, bufferLength, false, false, true);
+        buffer.setSize (1, bufferLength, false, false, true);
         reset();
     }
-    
-    void writeBuffer(T input)
+
+    void writeBuffer (T input)
     {
         /** setting a buffer size that is power of two and creating
             a mask to ANDOR the read/write index with. a faster way
@@ -47,21 +47,20 @@ public:
             mask = bufferSize - 1
          
          */
-        buffer.setSample(0, writeIndex++, input);
+        buffer.setSample (0, writeIndex++, input);
         writeIndex &= wrapMask;
     }
-    
-    T readBuffer(int delayInSamples, bool readBeforeWrite)
+
+    T readBuffer (int delayInSamples, bool readBeforeWrite)
     {
         // This implementation assumes that data will be read, then written
         // Pirkle implementation has a version with bool readBeforeWrite
         // commented out. Decided to bring it back here. TODO: remember why.
         int readIndex = (writeIndex - (readBeforeWrite ? 1 : 0)) - delayInSamples;
         readIndex &= wrapMask;
-        return buffer.getSample(0, readIndex);
+        return buffer.getSample (0, readIndex);
     }
-    
-    
+
 private:
     juce::AudioBuffer<T> buffer;
     int writeIndex = 0;

--- a/libs/Common/DSP/Compressor.h
+++ b/libs/Common/DSP/Compressor.h
@@ -17,57 +17,53 @@
 class Compressor
 {
 public:
-
     Compressor (bool autoRelease, float knee);
-    
+
     Compressor (bool autoRelease);
-    
+
     void reset (int numSamplesPerBlock);
-    
-    void setSampleRate (double inSampleRate) ;
-    
+
+    void setSampleRate (double inSampleRate);
+
     void setParams (float inAttack,
                     float inRelease,
                     float inRatio,
                     float inThreshold,
                     float inKnee);
 
-    void makeMonoSidechain (const juce::dsp::AudioBlock<float> &inAudio, juce::AudioBuffer<float> &scSignal);
-    
+    void makeMonoSidechain (const juce::dsp::AudioBlock<float>& inAudio, juce::AudioBuffer<float>& scSignal);
+
     void makeKneeCoeffs();
-    
+
     float calculateGain (float analysisSample);
 
-    void process (juce::dsp::AudioBlock<float> &inAudio);
-    
+    void process (juce::dsp::AudioBlock<float>& inAudio);
+
     float getMakeupGain();
-    
+
     void setAttack (float inAttack);
     void setRelease (float inRelease);
     void setRatio (float inRatio);
     void setKnee (float inKnee);
     void setThreshold (float inThreshold);
-    
+
     void setMeterSource (FFAU::LevelMeterSource* source);
     void setOversampleMultiplier (const int o);
-   
-    
-private:
 
+private:
     juce::WeakReference<FFAU::LevelMeterSource> meterSource;
-    
-    juce::Atomic<float> ratio {-1.0f},
-                  knee {-1.0f},
-                  msAttack {-1.0f},
-                  msRelease {-1.0f},
-                  threshold {-1.0};
-    
-    bool autoReleaseFlag{false};
-    EnvelopeDetector levelDetector{autoReleaseFlag};
+
+    juce::Atomic<float> ratio { -1.0f },
+        knee { -1.0f },
+        msAttack { -1.0f },
+        msRelease { -1.0f },
+        threshold { -1.0 };
+
+    bool autoReleaseFlag { false };
+    EnvelopeDetector levelDetector { autoReleaseFlag };
     juce::AudioBuffer<float> analysisSignal;
 
-    int overSampleMultiplier {1};
+    int overSampleMultiplier { 1 };
 
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Compressor)
-
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (Compressor)
 };

--- a/libs/Common/DSP/DigiDegraders.cpp
+++ b/libs/Common/DSP/DigiDegraders.cpp
@@ -11,8 +11,7 @@
 #include "DigiDegraders.h"
 #include "Common/DSP/AudioHelpers.h"
 
-
-void SimpleZOH::setResampleOffset(double inHostSr)
+void SimpleZOH::setResampleOffset (double inHostSr)
 {
     /*
         this allows the ZOH to act the same regardless of
@@ -22,32 +21,32 @@ void SimpleZOH::setResampleOffset(double inHostSr)
         a selected downsample ratio of 2 will result in a downsample ratio of 4
      */
     auto currentSR = currentHostSampleRate.get();
-    
-    if(inHostSr != currentSR)
+
+    if (inHostSr != currentSR)
     {
         resampleOffset = 1.0f;
     }
 }
 
-void SimpleZOH::setParams(float inDownsampleCoeff, bool sampleRateChanged)
+void SimpleZOH::setParams (float inDownsampleCoeff, bool sampleRateChanged)
 {
     downsampleCoeff = inDownsampleCoeff;
 }
 
-void SimpleZOH::processBlock(juce:: AudioBuffer<float> &inAudio, int samplesPerBlock, int numChannels)
+void SimpleZOH::processBlock (juce::AudioBuffer<float>& inAudio, int samplesPerBlock, int numChannels)
 {
-    auto intDownSampleCoeff = static_cast<int>(downsampleCoeff);
+    auto intDownSampleCoeff = static_cast<int> (downsampleCoeff);
     auto frac = downsampleCoeff - intDownSampleCoeff;
-    
+
     for (int channel = 0; channel < numChannels; ++channel)
     {
-        auto channelData = inAudio.getWritePointer(channel);
-        
+        auto channelData = inAudio.getWritePointer (channel);
+
         for (int sample = 0; sample < samplesPerBlock; ++sample)
         {
-            auto y1 = getZOHSample(channelData, sample, intDownSampleCoeff );
-            auto y2 = getZOHSample(channelData, sample, intDownSampleCoeff + 1);
-            channelData[sample] = tote_bag::audio_helpers::linearInterp(y1, y2, frac);
+            auto y1 = getZOHSample (channelData, sample, intDownSampleCoeff);
+            auto y2 = getZOHSample (channelData, sample, intDownSampleCoeff + 1);
+            channelData[sample] = tote_bag::audio_helpers::linearInterp (y1, y2, frac);
         }
     }
 }
@@ -56,43 +55,43 @@ inline float SimpleZOH::getZOHSample (const float* channelData, int sampleIndex,
 {
     if (dsCoef <= 1)
         return channelData[sampleIndex];
-    
+
     auto remainder = sampleIndex % dsCoef;
-    
+
     return remainder == 0 ? channelData[sampleIndex] : channelData[sampleIndex - remainder];
 }
 
 //=====================================================================================
 
-void Bitcrusher::setParams(float inBitDepth)
+void Bitcrusher::setParams (float inBitDepth)
 {
-        bitDepth.set (inBitDepth);
+    bitDepth.set (inBitDepth);
 }
 
-void Bitcrusher::processBlock(juce::AudioBuffer<float> &inAudio, int samplesPerBlock, int numChannels)
+void Bitcrusher::processBlock (juce::AudioBuffer<float>& inAudio, int samplesPerBlock, int numChannels)
 {
     auto bD = bitDepth.get();
-    auto intBitDepth = static_cast<int>(bD);
+    auto intBitDepth = static_cast<int> (bD);
     auto frac = bD - intBitDepth;
-    
+
     for (int channel = 0; channel < numChannels; ++channel)
     {
-        auto channelData = inAudio.getWritePointer(channel);
-        
+        auto channelData = inAudio.getWritePointer (channel);
+
         for (int sample = 0; sample < samplesPerBlock; ++sample)
         {
             const float inputSample = channelData[sample];
-            auto y1 = getBitcrushedSample(inputSample, intBitDepth );
-            auto y2 = getBitcrushedSample(inputSample, intBitDepth + 1);
+            auto y1 = getBitcrushedSample (inputSample, intBitDepth);
+            auto y2 = getBitcrushedSample (inputSample, intBitDepth + 1);
 
-            channelData[sample] = tote_bag::audio_helpers::linearInterp(y1, y2, frac);
+            channelData[sample] = tote_bag::audio_helpers::linearInterp (y1, y2, frac);
         }
     }
 }
 
 inline float Bitcrusher::getBitcrushedSample (float inputSample, int bits)
 {
-    auto q = 1.0f / (pow(2.0f, bits) - 1);
-    
-    return q * (floor(inputSample / q));
+    auto q = 1.0f / (pow (2.0f, bits) - 1);
+
+    return q * (floor (inputSample / q));
 }

--- a/libs/Common/DSP/DigiDegraders.h
+++ b/libs/Common/DSP/DigiDegraders.h
@@ -13,32 +13,29 @@
 #include <juce_audio_basics/juce_audio_basics.h>
 #include <juce_core/juce_core.h>
 
-#include <cstdlib>
-#include <cmath>
-#include <limits>
 #include <atomic>
+#include <cmath>
+#include <cstdlib>
+#include <limits>
 
 class SimpleZOH
 {
 public:
-    
-    SimpleZOH(){};
-    
-    void setResampleOffset(double inHostSr);
-    void setParams (float inDownsampleCoeff, bool sampleRateChanged);
-    void processBlock (juce::AudioBuffer<float> &inAudio, int samplesPerBlock, int numChannels);
-    float getZOHSample ( const float* channelData, int sampleIndex, int dsCoef );
-    
-private:
-    
-    float resampleOffset {-1},
-          downsampleCoeff {1.0f};
-    bool sampleRateChanged {true};
-    const double refSampleRate{44100};
-    juce::Atomic<double> currentHostSampleRate;
-    
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SimpleZOH)
+    SimpleZOH() {};
 
+    void setResampleOffset (double inHostSr);
+    void setParams (float inDownsampleCoeff, bool sampleRateChanged);
+    void processBlock (juce::AudioBuffer<float>& inAudio, int samplesPerBlock, int numChannels);
+    float getZOHSample (const float* channelData, int sampleIndex, int dsCoef);
+
+private:
+    float resampleOffset { -1 },
+        downsampleCoeff { 1.0f };
+    bool sampleRateChanged { true };
+    const double refSampleRate { 44100 };
+    juce::Atomic<double> currentHostSampleRate;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (SimpleZOH)
 };
 
 //====================================================================================
@@ -46,17 +43,14 @@ private:
 class Bitcrusher
 {
 public:
-    
-    Bitcrusher(){};
-    
-    void setParams (float inBitDepth);
-    void processBlock (juce::AudioBuffer<float> &inAudio, int samplesPerBlock, int numChannels);
-    float getBitcrushedSample (float inputSample, int bits);
-    
-private:
-    
-    juce::Atomic<float> bitDepth {16.0f};
-    
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Bitcrusher);
+    Bitcrusher() {};
 
+    void setParams (float inBitDepth);
+    void processBlock (juce::AudioBuffer<float>& inAudio, int samplesPerBlock, int numChannels);
+    float getBitcrushedSample (float inputSample, int bits);
+
+private:
+    juce::Atomic<float> bitDepth { 16.0f };
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (Bitcrusher);
 };

--- a/libs/Common/DSP/EnvelopeDetector.cpp
+++ b/libs/Common/DSP/EnvelopeDetector.cpp
@@ -15,8 +15,8 @@
 
 #include <math.h>
 
-EnvelopeDetector::EnvelopeDetector (bool autoReleaseFlag) :
-autoMode(autoReleaseFlag)
+EnvelopeDetector::EnvelopeDetector (bool autoReleaseFlag)
+    : autoMode (autoReleaseFlag)
 {
 }
 
@@ -26,12 +26,12 @@ void EnvelopeDetector::reset()
     currentGain.set (0.0);
 }
 
-void EnvelopeDetector::setSampleRate(double inSampleRate)
+void EnvelopeDetector::setSampleRate (double inSampleRate)
 {
     if (sampleRate.get() != inSampleRate)
     {
         sampleRate.set (inSampleRate);
-        
+
         setTimeConstant (msAttack.get(), true);
         setTimeConstant (msRelease.get(), false);
     }
@@ -40,35 +40,35 @@ void EnvelopeDetector::setSampleRate(double inSampleRate)
 void EnvelopeDetector::setTimeConstant (double inTime, bool attack)
 {
     jassert (inTime > 0.0);
-    
+
     auto sr = sampleRate.get();
-    
+
     auto timeCoeff = setCoefficient (inTime,
                                      kEnvelopeTimeConstant,
                                      sr);
     if (attack)
     {
         tauAttack.set (timeCoeff);
-        msAttack.set(inTime);
+        msAttack.set (inTime);
     }
     else
     {
         tauRelease.set (timeCoeff);
-        msRelease.set(inTime);
-        
+        msRelease.set (inTime);
+
         if (autoMode)
             tauSlowRelease.set (setCoefficient (inTime * slowReleaseMultiplier, kEnvelopeTimeConstant, sr));
     }
 }
 
 inline double EnvelopeDetector::setCoefficient (double timeInMilliseconds,
-                                         double timeScalar,
-                                         double sampleRate)
+                                                double timeScalar,
+                                                double sampleRate)
 {
-    return exp(timeScalar / (0.001 * timeInMilliseconds * sampleRate));
+    return exp (timeScalar / (0.001 * timeInMilliseconds * sampleRate));
 }
 
-void EnvelopeDetector::updateCurrentGain (double inGain) {currentGain.set (inGain); }
+void EnvelopeDetector::updateCurrentGain (double inGain) { currentGain.set (inGain); }
 
 inline double EnvelopeDetector::getReleaseCoefficient()
 {
@@ -81,12 +81,11 @@ inline double EnvelopeDetector::getReleaseCoefficient()
 double EnvelopeDetector::processSampleDecoupledBranched (double inputSample)
 {
     juce::ScopedNoDenormals noDenormals;
-    
+
     auto prevOutput = prevEnv.get();
-    auto coeff  = inputSample > prevOutput ? tauAttack.get() : tauRelease.get();
+    auto coeff = inputSample > prevOutput ? tauAttack.get() : tauRelease.get();
     auto smoothedSample = coeff * (prevOutput - inputSample) + inputSample;
     prevEnv.set (smoothedSample);
 
-    return  smoothedSample;
+    return smoothedSample;
 }
-

--- a/libs/Common/DSP/EnvelopeDetector.h
+++ b/libs/Common/DSP/EnvelopeDetector.h
@@ -18,54 +18,50 @@
 class EnvelopeDetector
 {
 public:
-    
     EnvelopeDetector (bool autoReleaseFlag);
-    
+
     void reset();
-    
-    void setSampleRate( double inSampleRate );
-    
+
+    void setSampleRate (double inSampleRate);
+
     void setParams (double inAttack, double inRelease);
-    
-    void setTimeConstant( double inTime, bool attack );
-    
+
+    void setTimeConstant (double inTime, bool attack);
+
     /** returns a release coefficient depending on whether or not the envelope
         has been set to auto, and then whether or not it meets the threshold
         to used the slow attack
      */
     double getReleaseCoefficient();
-    
-    double processSampleDecoupledBranched ( double inputSample );
-    
-    void updateAutoReleaseCounter(bool advance);
-    
-    void updateCurrentGain(double inGain);
-    
+
+    double processSampleDecoupledBranched (double inputSample);
+
+    void updateAutoReleaseCounter (bool advance);
+
+    void updateCurrentGain (double inGain);
+
     /** sets the time coefficients used in envelope detector
     */
-    static double setCoefficient( double timeInMilliseconds,
-                                 double timeScalar,
-                                 double sampleRate);
-    
-private:
+    static double setCoefficient (double timeInMilliseconds,
+                                  double timeScalar,
+                                  double sampleRate);
 
-    bool autoMode {false};
-    
-    juce::Atomic<double> sampleRate {0.0},
-                   prevEnv {0.0},
-                   currentGain {0.0},
-                   msAttack  {-1},
-                   msRelease {-1},
-                   tauAttack {0.0},
-                   tauRelease {0.0},
-                   tauSlowRelease {0.0};
-    
-    const double slowReleaseThreshold {-12.0};
-    const int slowReleaseMultiplier {2};
+private:
+    bool autoMode { false };
+
+    juce::Atomic<double> sampleRate { 0.0 },
+        prevEnv { 0.0 },
+        currentGain { 0.0 },
+        msAttack { -1 },
+        msRelease { -1 },
+        tauAttack { 0.0 },
+        tauRelease { 0.0 },
+        tauSlowRelease { 0.0 };
+
+    const double slowReleaseThreshold { -12.0 };
+    const int slowReleaseMultiplier { 2 };
 
     static constexpr double kEnvelopeTimeConstant = -0.99967234081320612357829304641019;
 
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(EnvelopeDetector)
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (EnvelopeDetector)
 };
-
-

--- a/libs/Common/DSP/LagrangeInterpolator.h
+++ b/libs/Common/DSP/LagrangeInterpolator.h
@@ -23,20 +23,20 @@ From Pirkle's FXObjects.h
 \param xbar - The x-coorinates whose y-value we want to interpolate
 \return the interpolated value
 */
-inline double doLagrangeInterpolation(double* x, double* y, int n, double xbar)
+inline double doLagrangeInterpolation (double* x, double* y, int n, double xbar)
 {
     int i, j;
     double fx = 0.0;
     double l = 1.0;
-    for (i = 0; i<n; i++)
+    for (i = 0; i < n; i++)
     {
         l = 1.0;
-        for (j = 0; j<n; j++)
+        for (j = 0; j < n; j++)
         {
             if (j != i)
                 l *= (xbar - x[j]) / (x[i] - x[j]);
         }
-        fx += l*y[i];
+        fx += l * y[i];
     }
     return (fx);
 }

--- a/libs/Common/DSP/Saturation.cpp
+++ b/libs/Common/DSP/Saturation.cpp
@@ -11,53 +11,52 @@
 #include "Saturation.h"
 #include "Common/DSP/AudioHelpers.h"
 
-Saturation::Saturation  (Type sType, double asymm) :
-                           saturationType(sType),
-                           asymmetry(asymm)
-{}
-
-void Saturation::setParams(double inSaturation)
+Saturation::Saturation (Type sType, double asymm)
+    : saturationType (sType)
+    , asymmetry (asymm)
 {
-    smoothedSat.setTargetValue(inSaturation);
+}
+
+void Saturation::setParams (double inSaturation)
+{
+    smoothedSat.setTargetValue (inSaturation);
 }
 
 void Saturation::reset (double sampleRate)
 {
-    
-    if(xState.getNumChannels() > 0)
+    if (xState.getNumChannels() > 0)
         xState.clear();
-    
-    else if (saturationType==Type::inverseHyperbolicSineInterp ||
-             saturationType==Type::interpolatedHyperbolicTangent)
+
+    else if (saturationType == Type::inverseHyperbolicSineInterp || saturationType == Type::interpolatedHyperbolicTangent)
     {
-        xState.setSize(2, 1);
+        xState.setSize (2, 1);
         xState.clear();
         antiderivState.fill (0.0);
     }
-    
+
     smoothedSat.reset (sampleRate, gainRampSec);
 }
 
-inline double Saturation::calcGain(double inputSample, double sat)
+inline double Saturation::calcGain (double inputSample, double sat)
 {
-    return ((inputSample >= 0.0 && asymmetry > 0.0) || (inputSample < 0.0 && asymmetry < 0.0)) ? sat * (1.0 + 4.0 * abs(asymmetry)) : sat;
+    return ((inputSample >= 0.0 && asymmetry > 0.0) || (inputSample < 0.0 && asymmetry < 0.0)) ? sat * (1.0 + 4.0 * abs (asymmetry)) : sat;
 }
 
 //===============================================================================
 inline double Saturation::inverseHyperbolicSine (double x, double gain)
 {
     double xScaled = x * gain;
-    return log(xScaled + sqrt(xScaled * xScaled + 1.0)) / gain ;
+    return log (xScaled + sqrt (xScaled * xScaled + 1.0)) / gain;
 }
 
 inline float Saturation::inverseHyperbolicSineInterp (float x, float gain, int channel)
 {
-    auto stateSample = xState.getSample(channel, 0);
+    auto stateSample = xState.getSample (channel, 0);
     auto diff = x - stateSample;
-    
-    auto antiDeriv = invHypeSineAntiDeriv(x);
+
+    auto antiDeriv = invHypeSineAntiDeriv (x);
     auto output = 0.0f;
-    if (abs(diff) < 0.001f)
+    if (abs (diff) < 0.001f)
     {
         auto input = (x + stateSample) / 2.f;
         output = inverseHyperbolicSine (input, 1.0f);
@@ -67,106 +66,106 @@ inline float Saturation::inverseHyperbolicSineInterp (float x, float gain, int c
         output = (antiDeriv - antiderivState[channel]) / diff;
     }
 
-    xState.setSample(channel, 0,  x);
+    xState.setSample (channel, 0, x);
     antiderivState[channel] = antiDeriv;
-    
+
     return output;
 }
 
 inline float Saturation::invHypeSineAntiDeriv (float x)
 {
-    return x * inverseHyperbolicSine (x, 1.0f) - sqrt(x * x + 1.0);
+    return x * inverseHyperbolicSine (x, 1.0f) - sqrt (x * x + 1.0);
 }
 
-inline float Saturation::sineArcTangent(float x, float gain)
+inline float Saturation::sineArcTangent (float x, float gain)
 {
     float xScaled = x * gain;
-    return (xScaled / sqrt(1.f + xScaled * xScaled)) / gain ;
+    return (xScaled / sqrt (1.f + xScaled * xScaled)) / gain;
 }
 
-inline double Saturation::hyperbolicTangent(double x, double gain, int channel)
+inline double Saturation::hyperbolicTangent (double x, double gain, int channel)
 {
     double xScaled = x * gain;
-    return std::tanh(xScaled) / gain;
+    return std::tanh (xScaled) / gain;
 }
 
 inline double Saturation::interpolatedHyperbolicTangent (double x, double gain, int channel)
 
 {
-    auto stateSample = xState.getSample(channel, 0);
+    auto stateSample = xState.getSample (channel, 0);
     auto diff = x - stateSample;
     auto output = 0.0f;
-    auto antiDeriv = hyperTanFirstAntiDeriv(x);
+    auto antiDeriv = hyperTanFirstAntiDeriv (x);
 
-    if (abs(diff) < 0.001)
+    if (abs (diff) < 0.001)
     {
         auto input = (x + stateSample) / 2.f;
         output = hyperbolicTangent (input, 1.0f, channel);
     }
     else
     {
-            output = (antiDeriv - antiderivState[channel]) / diff;
+        output = (antiDeriv - antiderivState[channel]) / diff;
     }
 
-    xState.setSample(channel, 0,  x);
+    xState.setSample (channel, 0, x);
     antiderivState[channel] = antiDeriv;
 
     return output;
 }
 
-double Saturation::hyperTanFirstAntiDeriv(double x){
-
-    return std::log (tote_bag::audio_helpers::ClampedCosh(x));
+double Saturation::hyperTanFirstAntiDeriv (double x)
+{
+    return std::log (tote_bag::audio_helpers::ClampedCosh (x));
 }
 
 //===============================================================================
 
-inline double Saturation::processSample(double inputSample, int channel, double sat)
+inline double Saturation::processSample (double inputSample, int channel, double sat)
 {
-    auto gain = calcGain(inputSample, sat);
-    
+    auto gain = calcGain (inputSample, sat);
+
     // mod matrix?
     // function pointer?
     // branching can prevent optimization
-        // store a pointer to a processing class
-    
+    // store a pointer to a processing class
+
     switch (saturationType)
     {
         case Type::inverseHyperbolicSine:
-            return inverseHyperbolicSine(inputSample, gain);
-            
+            return inverseHyperbolicSine (inputSample, gain);
+
         case Type::sineArcTangent:
-            return sineArcTangent(inputSample, gain);
-            
+            return sineArcTangent (inputSample, gain);
+
         case Type::hyperbolicTangent:
-            return hyperbolicTangent(inputSample, gain, channel);
-        
+            return hyperbolicTangent (inputSample, gain, channel);
+
         case Type::inverseHyperbolicSineInterp:
-            return inverseHyperbolicSineInterp(inputSample*gain, gain, channel)/gain;
-            
+            return inverseHyperbolicSineInterp (inputSample * gain, gain, channel) / gain;
+
         case Type::interpolatedHyperbolicTangent:
-            return interpolatedHyperbolicTangent(inputSample*gain, gain, channel)/gain;
-        
+            return interpolatedHyperbolicTangent (inputSample * gain, gain, channel) / gain;
+
         default:
             //somehow the distortion type was not set. It must be set!
-            jassert(false);
+            jassert (false);
     }
 }
 
-void Saturation::processBlock( juce::dsp::AudioBlock<float> &inAudio )
+void Saturation::processBlock (juce::dsp::AudioBlock<float>& inAudio)
 {
     auto numChannels = inAudio.getNumChannels();
     auto samplesPerBlock = inAudio.getNumSamples();
-    
-    for ( int i = 0; i < samplesPerBlock; ++i )
+
+    for (int i = 0; i < samplesPerBlock; ++i)
     {
-        for ( int j = 0; j < numChannels; ++j)
+        for (int j = 0; j < numChannels; ++j)
         {
-            inAudio.setSample(j,
-                              i,
-                              processSample(inAudio.getSample(j, i),
-                                            j,
-                                            smoothedSat.getNextValue()));
+            inAudio.setSample (j,
+                               i,
+                               processSample (inAudio.getSample (j, i),
+                                              j,
+                                              smoothedSat.getNextValue()));
         }
     }
 }

--- a/libs/Common/DSP/Saturation.h
+++ b/libs/Common/DSP/Saturation.h
@@ -29,9 +29,7 @@
 class Saturation
 {
 public:
-    
-    enum class Type
-    {
+    enum class Type {
         inverseHyperbolicSine,
         sineArcTangent,
         hyperbolicTangent,
@@ -39,48 +37,46 @@ public:
         interpolatedHyperbolicTangent
     };
 
-    Saturation( Type sType, double asymm = 0.0 );
-  
-    void setParams(double inSaturation);
-    
-    void reset(double sampleRate);
-    
+    Saturation (Type sType, double asymm = 0.0);
+
+    void setParams (double inSaturation);
+
+    void reset (double sampleRate);
+
     inline double calcGain (double inputSample, double sat);
-    
+
     inline double processSample (double inputSample, int channel, double sat);
-    
-//==============================================================
-    
+
+    //==============================================================
+
     inline double inverseHyperbolicSine (double x, double gain);
-    
+
     inline float inverseHyperbolicSineInterp (float x, float gain, int channel);
-    
+
     inline float sineArcTangent (float x, float gain);
-    
+
     inline double hyperbolicTangent (double x, double gain, int channel);
-    
+
     inline double interpolatedHyperbolicTangent (double x, double gain, int channel);
-    
+
     inline double hyperTanFirstAntiDeriv (double x);
-    
-    inline float invHypeSineAntiDeriv(float x);
 
-//==============================================================
+    inline float invHypeSineAntiDeriv (float x);
 
-    void processBlock( juce::dsp::AudioBlock<float> &inAudio );
+    //==============================================================
+
+    void processBlock (juce::dsp::AudioBlock<float>& inAudio);
 
 private:
-
     Type saturationType;
 
-    double asymmetry {0.0};
+    double asymmetry { 0.0 };
 
-    const double gainRampSec {.005};
+    const double gainRampSec { .005 };
 
-    juce::SmoothedValue<double, juce::ValueSmoothingTypes::Linear> smoothedSat {1.0f};
+    juce::SmoothedValue<double, juce::ValueSmoothingTypes::Linear> smoothedSat { 1.0f };
     juce::AudioBuffer<double> xState;
     std::array<double, 2> antiderivState;
 
-   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Saturation)
-
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (Saturation)
 };

--- a/libs/Common/DSP/ThiranAllpass.h
+++ b/libs/Common/DSP/ThiranAllpass.h
@@ -34,27 +34,26 @@ struct ThiranScalars
        for a more flexible implementation
     
     */
-    
-    const std::array<int, 2> firstOrder = {1, -1};
-    const std::array<int, 5> fourthOrder = {1, -4, 6, -4, 1};
-    const std::array<int, 6> sixthOrder = {1, -5, 10, -10, 5, -1};
+
+    const std::array<int, 2> firstOrder = { 1, -1 };
+    const std::array<int, 5> fourthOrder = { 1, -4, 6, -4, 1 };
+    const std::array<int, 6> sixthOrder = { 1, -5, 10, -10, 5, -1 };
 };
 
 /** An allpass filter desined for fractional delay. Currently supports delay amounts
     < 1 sample, but theoretically could handle more (as shown by the above coefficient arrays).
  */
-template<typename T>
+template <typename T>
 class ThiranAllPass
 {
 public:
-        
     void reset()
     {
         xBuf.reset();
         yBuf.reset();
     }
-    
-    void prepare(T inDelay)
+
+    void prepare (T inDelay)
     {
         // This class needs to be refactored. It can only operate as a first order
         // filter, but here we accept an arbitrary delay amount. This will cause a
@@ -65,30 +64,30 @@ public:
         // it's truncated N is used to calculate our coefficients
         // TODO: make sure this can actually handle all the delay values that may be given to it.
         // TODO: conversely, refactor to only allow fractional delays of less than one sample.
-        jassert(inDelay < 1);
+        jassert (inDelay < 1);
 
         // get the desired delay and figure out filter order.
         if (delay != inDelay)
         {
             delay = inDelay;
-            N = static_cast<int>(delay);
+            N = static_cast<int> (delay);
             bufSize = N + 1;
 
-            xBuf.setSize(bufSize);
-            yBuf.setSize(bufSize);
-            
+            xBuf.setSize (bufSize);
+            yBuf.setSize (bufSize);
+
             makeCoefficients();
         }
     }
-    
+
     void makeCoefficients()
     {
         // from https://ccrma.stanford.edu/~jos/pasp/Thiran_Allpass_Interpolation_Matlab.html
-        
+
         if (aCoeffs.size() != bufSize)
-            aCoeffs.resize(bufSize);
+            aCoeffs.resize (bufSize);
         if (bCoeffs.size() != bufSize)
-            bCoeffs.resize(bufSize);
+            bCoeffs.resize (bufSize);
 
         //an attempt at ameliorating the level boost
         aCoeffs[0] = 0.7943282347242815;
@@ -96,51 +95,49 @@ public:
         for (int i = 1; i < N + 1; i++)
         {
             auto product = 1.0;
-            
-            for(int n = 0; n < N + 1; n++)
+
+            for (int n = 0; n < N + 1; n++)
             {
-                product = product * (delay - N + n) /
-                                    (delay - N + i + n);
-                
-                aCoeffs[i] = std::pow(-1, i) * scalars.firstOrder[i] * product;
+                product = product * (delay - N + n) / (delay - N + i + n);
+
+                aCoeffs[i] = std::pow (-1, i) * scalars.firstOrder[i] * product;
             }
         }
-        
+
         int k = N;
-        for(auto coeff : aCoeffs)
+        for (auto coeff : aCoeffs)
             bCoeffs[k--] = coeff;
     }
-    
+
     /** Take a mono AudioBlock and processes it
         Direct Form I since the order / delay is integral to the filtering
      */
-    void process(juce::dsp::AudioBlock<float>& inBlock)
+    void process (juce::dsp::AudioBlock<float>& inBlock)
     {
         juce::ScopedNoDenormals noDenormals;
-       
-        auto blockLen = inBlock.getNumSamples();
-        auto inAudio = inBlock.getChannelPointer(0);
 
-        for(int sample = 0; sample < blockLen; ++sample)
+        auto blockLen = inBlock.getNumSamples();
+        auto inAudio = inBlock.getChannelPointer (0);
+
+        for (int sample = 0; sample < blockLen; ++sample)
         {
             auto v = bCoeffs[0] * inAudio[sample];
-            
-            for(int i = 1; i < bCoeffs.size(); ++i )
-                v += bCoeffs[i] * xBuf.readBuffer(i, false);
-            
-            xBuf.writeBuffer(inAudio[sample]);
-            
-            for(int i = 1; i < aCoeffs.size(); ++i )
-                v -= aCoeffs[i] * yBuf.readBuffer(i, false);
-        
+
+            for (int i = 1; i < bCoeffs.size(); ++i)
+                v += bCoeffs[i] * xBuf.readBuffer (i, false);
+
+            xBuf.writeBuffer (inAudio[sample]);
+
+            for (int i = 1; i < aCoeffs.size(); ++i)
+                v -= aCoeffs[i] * yBuf.readBuffer (i, false);
+
             inAudio[sample] = v * aCoeffs[0];
-            
-            yBuf.writeBuffer(inAudio[sample]);
+
+            yBuf.writeBuffer (inAudio[sample]);
         }
     }
-    
+
 private:
-    
     std::vector<T> aCoeffs, bCoeffs;
     CircularBuffer<T> xBuf, yBuf;
     T delay;

--- a/libs/Common/GUI/Components/Panels/PresetPanel.cpp
+++ b/libs/Common/GUI/Components/Panels/PresetPanel.cpp
@@ -14,11 +14,11 @@
 PresetPanel::PresetPanel (ToteBagPresetManager& pManager,
                           const juce::String& bypassButtonText,
                           const juce::String& bypassParameterId,
-                          juce::AudioProcessorValueTreeState& treeState) :
- mBypassButton (bypassButtonText,
-                bypassParameterId,
-                treeState)
-,presetManager (pManager)
+                          juce::AudioProcessorValueTreeState& treeState)
+    : mBypassButton (bypassButtonText,
+                     bypassParameterId,
+                     treeState)
+    , presetManager (pManager)
 {
     // set up save and load buttons
     mSavePresetButton.setButtonText ("Save");
@@ -45,18 +45,18 @@ PresetPanel::PresetPanel (ToteBagPresetManager& pManager,
         handlePresetDisplaySelection();
     };
     mPresetDisplay.setText (currentPresetName, juce::dontSendNotification);
-    mPresetDisplay.setSelectedItemIndex(presetManager.getCurrentPresetIndex(), juce::dontSendNotification);
+    mPresetDisplay.setSelectedItemIndex (presetManager.getCurrentPresetIndex(), juce::dontSendNotification);
 
     updatePresetComboBox();
 
     // set up preset iterator buttons
-    mNextPreset.setButtonText(">");
+    mNextPreset.setButtonText (">");
     mNextPreset.onClick = [this]() { incrementPreset(); };
-    addAndMakeVisible(mNextPreset);
+    addAndMakeVisible (mNextPreset);
 
-    mPreviousPreset.setButtonText("<");
+    mPreviousPreset.setButtonText ("<");
     mPreviousPreset.onClick = [this]() { decrementPreset(); };
-    addAndMakeVisible(mPreviousPreset);
+    addAndMakeVisible (mPreviousPreset);
 
     startTimerHz (20);
 }
@@ -66,9 +66,9 @@ PresetPanel::~PresetPanel()
     stopTimer();
 }
 
-void PresetPanel::paint(juce::Graphics& g)
+void PresetPanel::paint (juce::Graphics& g)
 {
-    g.setColour(juce::Colours::darkgrey);
+    g.setColour (juce::Colours::darkgrey);
     g.fillAll();
 }
 
@@ -79,7 +79,7 @@ void PresetPanel::incrementPreset()
     {
         newPresetIndex = 0;
     }
-    presetManager.loadPreset(newPresetIndex);
+    presetManager.loadPreset (newPresetIndex);
 }
 
 void PresetPanel::decrementPreset()
@@ -89,7 +89,7 @@ void PresetPanel::decrementPreset()
     {
         newPresetIndex = presetManager.getNumberOfPresets() - 1;
     }
-    presetManager.loadPreset(newPresetIndex);
+    presetManager.loadPreset (newPresetIndex);
 }
 
 void PresetPanel::savePreset()
@@ -97,11 +97,11 @@ void PresetPanel::savePreset()
     auto currentPresetName = presetManager.getCurrentPresetName();
 
     juce::String currentPresetPath = presetManager.getCurrentPresetDirectory()
-                               + static_cast<std::string>(directorySeparator) + currentPresetName;
+                                     + static_cast<std::string> (directorySeparator) + currentPresetName;
 
     juce::FileChooser chooser ("Save a file: ",
                                juce::File (currentPresetPath),
-                               static_cast<std::string>(presetFileExtensionWildcard));
+                               static_cast<std::string> (presetFileExtensionWildcard));
 
     if (chooser.browseForFileToSave (true))
     {
@@ -119,17 +119,15 @@ void PresetPanel::loadPreset()
 
     if (currentPresetDirectory.isNotEmpty())
     {
-
         juce::FileChooser chooser ("Load a file: ",
                                    juce::File (currentPresetDirectory),
-                                   static_cast<std::string>(presetFileExtensionWildcard));
+                                   static_cast<std::string> (presetFileExtensionWildcard));
 
         if (chooser.browseForFileToOpen())
         {
             juce::File presetToLoad (chooser.getResult());
 
             presetManager.loadPreset (presetToLoad);
-
         }
     }
 }
@@ -159,9 +157,9 @@ void PresetPanel::updatePresetComboBox()
 
     const int numPresets = presetManager.getNumberOfPresets();
 
-    for(int i = 0;  i < numPresets; i++)
+    for (int i = 0; i < numPresets; i++)
     {
-        mPresetDisplay.addItem (presetManager.getPresetName (i), (i+1));
+        mPresetDisplay.addItem (presetManager.getPresetName (i), (i + 1));
     }
 
     mPresetDisplay.setText (presetManager.getCurrentPresetName(), juce::dontSendNotification);
@@ -170,7 +168,7 @@ void PresetPanel::updatePresetComboBox()
 void PresetPanel::resized()
 {
     const auto area = getLocalBounds();
-    const auto margin = juce::roundToInt(area.getHeight() * .1f);
+    const auto margin = juce::roundToInt (area.getHeight() * .1f);
 
     // Adjust width to account for margins
     const auto actualWidth = area.getWidth() - (margin * 6);
@@ -183,36 +181,36 @@ void PresetPanel::resized()
 
     auto x = area.getX() + margin; // We update this while we place components
     const auto y = area.getY() + margin;
-    const auto h = juce::roundToInt(area.getHeight() - (margin * 2.0f));
+    const auto h = juce::roundToInt (area.getHeight() - (margin * 2.0f));
 
     // Place bypass button
-    const auto bypassButtonWidth = juce::roundToInt(bypassAreaWidth);
-    juce::Rectangle<int> bypassBounds{x, y, bypassButtonWidth, h};
-    mBypassButton.setBounds(bypassBounds);
+    const auto bypassButtonWidth = juce::roundToInt (bypassAreaWidth);
+    juce::Rectangle<int> bypassBounds { x, y, bypassButtonWidth, h };
+    mBypassButton.setBounds (bypassBounds);
     x += (bypassButtonWidth + margin);
 
     // Place save and load buttons
-    const auto saveLoadButtonWidth = juce::roundToInt(saveLoadAreaWidth * .5f);
+    const auto saveLoadButtonWidth = juce::roundToInt (saveLoadAreaWidth * .5f);
     juce::Rectangle<int> saveLoadBounds;
-    for (auto button : {&mSavePresetButton, &mLoadPresetButton})
+    for (auto button : { &mSavePresetButton, &mLoadPresetButton })
     {
-        saveLoadBounds.setBounds(x, y, saveLoadButtonWidth, h);
-        button->setBounds(saveLoadBounds);
+        saveLoadBounds.setBounds (x, y, saveLoadButtonWidth, h);
+        button->setBounds (saveLoadBounds);
         x += (saveLoadButtonWidth + margin);
     }
 
     // Place increment and decrement buttons
     juce::Rectangle<int> incrementDecrementBounds;
-    const auto incrementDecrementButtonWidth = juce::roundToInt(incrementDecrementAreaWidth * .5f);
-    for (auto button : {&mPreviousPreset, &mNextPreset})
+    const auto incrementDecrementButtonWidth = juce::roundToInt (incrementDecrementAreaWidth * .5f);
+    for (auto button : { &mPreviousPreset, &mNextPreset })
     {
-        incrementDecrementBounds.setBounds(x, y, incrementDecrementButtonWidth, h);
-        button->setBounds(incrementDecrementBounds);
+        incrementDecrementBounds.setBounds (x, y, incrementDecrementButtonWidth, h);
+        button->setBounds (incrementDecrementBounds);
         x += (incrementDecrementButtonWidth + margin);
     }
 
     // Place preset selection window
     const auto presetAreaWidth = actualWidth - buttonAreaWidth;
-    juce::Rectangle<int> presetSelectorBounds{x, y, juce::roundToInt(presetAreaWidth) - margin, h};
-    mPresetDisplay.setBounds(presetSelectorBounds);
+    juce::Rectangle<int> presetSelectorBounds { x, y, juce::roundToInt (presetAreaWidth) - margin, h };
+    mPresetDisplay.setBounds (presetSelectorBounds);
 }

--- a/libs/Common/GUI/Components/Panels/PresetPanel.h
+++ b/libs/Common/GUI/Components/Panels/PresetPanel.h
@@ -15,19 +15,18 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 
 class ToteBagPresetManager;
-class PresetPanel  : public juce::Component,
-                     public juce::Timer
+class PresetPanel : public juce::Component,
+                    public juce::Timer
 {
 public:
-    
     PresetPanel (ToteBagPresetManager& pManager,
                  const juce::String& bypassButtonText,
                  const juce::String& bypassParameterId,
                  juce::AudioProcessorValueTreeState& treeState);
     ~PresetPanel();
-    
+
     void paint (juce::Graphics& g) override;
-    
+
     void incrementPreset();
 
     void decrementPreset();
@@ -37,15 +36,14 @@ public:
     void loadPreset();
 
     void handlePresetDisplaySelection();
-    
+
     void resized() override;
-            
+
     void timerCallback() override;
-    
+
     void updatePresetComboBox();
-    
+
 private:
-    
     juce::TextButton mSavePresetButton;
     juce::TextButton mLoadPresetButton;
     juce::TextButton mPreviousPreset;
@@ -54,10 +52,9 @@ private:
 
     juce::ComboBox mPresetDisplay;
 
-    juce::String currentPresetName {"Untitled"};
-    
+    juce::String currentPresetName { "Untitled" };
+
     ToteBagPresetManager& presetManager;
-    
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (PresetPanel)
 };
-

--- a/libs/Common/GUI/Components/Panels/VerticalMeterPanel.cpp
+++ b/libs/Common/GUI/Components/Panels/VerticalMeterPanel.cpp
@@ -15,29 +15,29 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 
 //==============================================================================
-VerticalMeterPanel::VerticalMeterPanel(const juce::String& label,
-                                       ReductionMeterPlacement grMeterPlacement,
-                                       foleys::LevelMeterSource* levelMeterSource,
-                                       foleys::LevelMeterSource* grMeterSource) :
-grMeterPlacement(grMeterPlacement)
+VerticalMeterPanel::VerticalMeterPanel (const juce::String& label,
+                                        ReductionMeterPlacement grMeterPlacement,
+                                        foleys::LevelMeterSource* levelMeterSource,
+                                        foleys::LevelMeterSource* grMeterSource)
+    : grMeterPlacement (grMeterPlacement)
 {
     using namespace tote_bag::laf_constants;
 
-    metersLookAndFeel.setColour(FFAU::LevelMeter::lmBackgroundColour, vPink);
-    metersLookAndFeel.setColour(FFAU::LevelMeter::lmMeterGradientLowColour, (vGreen1));
-    metersLookAndFeel.setColour(FFAU::LevelMeter::lmMeterGradientMidColour, vGreen2);
-    metersLookAndFeel.setColour(FFAU::LevelMeter::lmMeterMaxOverColour, vRed);
-    
-    levelMeter.setLookAndFeel(&metersLookAndFeel);
-    levelMeter.setMeterSource(levelMeterSource);
-    addAndMakeVisible(levelMeter);
+    metersLookAndFeel.setColour (FFAU::LevelMeter::lmBackgroundColour, vPink);
+    metersLookAndFeel.setColour (FFAU::LevelMeter::lmMeterGradientLowColour, (vGreen1));
+    metersLookAndFeel.setColour (FFAU::LevelMeter::lmMeterGradientMidColour, vGreen2);
+    metersLookAndFeel.setColour (FFAU::LevelMeter::lmMeterMaxOverColour, vRed);
 
-    if(grMeterSource)
+    levelMeter.setLookAndFeel (&metersLookAndFeel);
+    levelMeter.setMeterSource (levelMeterSource);
+    addAndMakeVisible (levelMeter);
+
+    if (grMeterSource)
     {
-        gainReductionMeter = std::make_unique<FFAU::LevelMeter>(FFAU::LevelMeter::MeterFlags::Reduction);
-        gainReductionMeter->setMeterSource(grMeterSource);
-        gainReductionMeter->setLookAndFeel(&metersLookAndFeel);
-        addAndMakeVisible(gainReductionMeter.get());
+        gainReductionMeter = std::make_unique<FFAU::LevelMeter> (FFAU::LevelMeter::MeterFlags::Reduction);
+        gainReductionMeter->setMeterSource (grMeterSource);
+        gainReductionMeter->setLookAndFeel (&metersLookAndFeel);
+        addAndMakeVisible (gainReductionMeter.get());
     }
 }
 
@@ -54,16 +54,13 @@ void VerticalMeterPanel::resized()
     const auto areaWidth = area.getWidth();
 
     // get gr and meters width
-    const auto grMeterWidth = juce::roundToInt(areaWidth * .25f);
+    const auto grMeterWidth = juce::roundToInt (areaWidth * .25f);
 
+    const auto grMeterBounds = (grMeterPlacement & ReductionMeterPlacement::Left) ? area.removeFromLeft (grMeterWidth) : area.removeFromRight (grMeterWidth);
 
-    const auto grMeterBounds = (grMeterPlacement & ReductionMeterPlacement::Left) ?
-                               area.removeFromLeft(grMeterWidth) : area.removeFromRight(grMeterWidth);
-
-    if(gainReductionMeter.get())
+    if (gainReductionMeter.get())
     {
-        gainReductionMeter->setBounds(grMeterBounds);
+        gainReductionMeter->setBounds (grMeterBounds);
     }
-    levelMeter.setBounds(area);
-
+    levelMeter.setBounds (area);
 }

--- a/libs/Common/GUI/Components/Panels/VerticalMeterPanel.h
+++ b/libs/Common/GUI/Components/Panels/VerticalMeterPanel.h
@@ -16,8 +16,7 @@
 
 //==============================================================================
 
-enum ReductionMeterPlacement
-{
+enum ReductionMeterPlacement {
     Left = 1,
     Right = 1 << 1,
     None = 1 << 2
@@ -25,23 +24,22 @@ enum ReductionMeterPlacement
 
 class ValentineAudioProcessor;
 
-class VerticalMeterPanel  : public juce::Component
+class VerticalMeterPanel : public juce::Component
 {
 public:
-    VerticalMeterPanel(const juce::String& label,
-                       ReductionMeterPlacement grMeterPlacement,
-                       foleys::LevelMeterSource* levelMeterSource,
-                       foleys::LevelMeterSource* grMeterSource = nullptr);
+    VerticalMeterPanel (const juce::String& label,
+                        ReductionMeterPlacement grMeterPlacement,
+                        foleys::LevelMeterSource* levelMeterSource,
+                        foleys::LevelMeterSource* grMeterSource = nullptr);
 
     ~VerticalMeterPanel() override;
 
     void resized() override;
 
 private:
-
     tote_bag::LookAndFeel metersLookAndFeel;
 
-    FFAU::LevelMeter levelMeter {FFAU::LevelMeter::MeterFlags::Minimal};
+    FFAU::LevelMeter levelMeter { FFAU::LevelMeter::MeterFlags::Minimal };
 
     std::unique_ptr<FFAU::LevelMeter> gainReductionMeter;
 

--- a/libs/Common/GUI/Components/Widgets/FlatTextButton.cpp
+++ b/libs/Common/GUI/Components/Widgets/FlatTextButton.cpp
@@ -14,20 +14,17 @@
 namespace tote_bag
 {
 
-FlatTextButton::FlatTextButton(juce::String name) : TextButton(name)
-{    
+FlatTextButton::FlatTextButton (juce::String name)
+    : TextButton (name)
+{
 }
 
 void FlatTextButton::paintButton (juce::Graphics& g, bool shouldDrawButtonAsHighlighted, bool shouldDrawButtonAsDown)
 {
-
     if (auto* lnf = dynamic_cast<LookAndFeel*> (&getLookAndFeel()))
     {
-
-        lnf->drawFlatButtonBackground(g, *this,
-                                  findColour (getToggleState() ? buttonOnColourId : buttonColourId),
-                                  shouldDrawButtonAsHighlighted, shouldDrawButtonAsDown);
-        lnf->drawButtonText(g, *this, shouldDrawButtonAsHighlighted, shouldDrawButtonAsDown);
+        lnf->drawFlatButtonBackground (g, *this, findColour (getToggleState() ? buttonOnColourId : buttonColourId), shouldDrawButtonAsHighlighted, shouldDrawButtonAsDown);
+        lnf->drawButtonText (g, *this, shouldDrawButtonAsHighlighted, shouldDrawButtonAsDown);
     }
     else
     {
@@ -35,6 +32,5 @@ void FlatTextButton::paintButton (juce::Graphics& g, bool shouldDrawButtonAsHigh
         // Make sure it is being set by the top level GUI component.
         jassertfalse;
     }
-
 }
 } // namespace totebag

--- a/libs/Common/GUI/Components/Widgets/FlatTextButton.h
+++ b/libs/Common/GUI/Components/Widgets/FlatTextButton.h
@@ -18,14 +18,11 @@ namespace tote_bag
 class FlatTextButton : public juce::TextButton
 {
 public:
+    FlatTextButton (juce::String name);
 
-    FlatTextButton(juce::String name);
-    
 protected:
-
     void paintButton (juce::Graphics& g,
                       bool shouldDrawButtonAsHighlighted,
                       bool shouldDrawButtonAsDown) override;
-
 };
-}// namespace totebag
+} // namespace totebag

--- a/libs/Common/GUI/Components/Widgets/FlatTextChooser.cpp
+++ b/libs/Common/GUI/Components/Widgets/FlatTextChooser.cpp
@@ -17,26 +17,26 @@
 namespace tote_bag
 {
 
-FlatTextChooser::FlatTextChooser(const juce::String& labelText,
-                                 const std::vector<std::string>& choices,
-                                 int paramGroupId,
-                                 juce::AudioParameterChoice* param = nullptr,
-                                 bool alignWithParameterSliders = false) :
- mLabel(labelText + " Chooser", labelText)
-,mParameter(param)
-,mAlignWithParameterSliders(alignWithParameterSliders)
+FlatTextChooser::FlatTextChooser (const juce::String& labelText,
+                                  const std::vector<std::string>& choices,
+                                  int paramGroupId,
+                                  juce::AudioParameterChoice* param = nullptr,
+                                  bool alignWithParameterSliders = false)
+    : mLabel (labelText + " Chooser", labelText)
+    , mParameter (param)
+    , mAlignWithParameterSliders (alignWithParameterSliders)
 {
-    mLabel.setColour(juce::Label::textColourId, juce::Colours::black);
-    mLabel.setJustificationType(juce::Justification::centredTop);
+    mLabel.setColour (juce::Label::textColourId, juce::Colours::black);
+    mLabel.setJustificationType (juce::Justification::centredTop);
 
-    addAndMakeVisible(mLabel);
-    
+    addAndMakeVisible (mLabel);
+
     for (const auto& choiceLabelText : choices)
     {
-        auto button = mButtons.add(std::make_unique<FlatTextButton>(choiceLabelText));
+        auto button = mButtons.add (std::make_unique<FlatTextButton> (choiceLabelText));
 
         int edgesFlag = 0;
-        if(choiceLabelText == choices.front())
+        if (choiceLabelText == choices.front())
         {
             edgesFlag = juce::Button::ConnectedEdgeFlags::ConnectedOnBottom;
         }
@@ -46,21 +46,21 @@ FlatTextChooser::FlatTextChooser(const juce::String& labelText,
         }
         else
         {
-           edgesFlag = juce::Button::ConnectedEdgeFlags::ConnectedOnTop
-                     | juce::Button::ConnectedEdgeFlags::ConnectedOnBottom;
+            edgesFlag = juce::Button::ConnectedEdgeFlags::ConnectedOnTop
+                        | juce::Button::ConnectedEdgeFlags::ConnectedOnBottom;
         }
 
-        button->setConnectedEdges(edgesFlag);
-        addAndMakeVisible(button);
+        button->setConnectedEdges (edgesFlag);
+        addAndMakeVisible (button);
     }
 
     if (param)
     {
-        mButtonState = std::make_unique<RadioButtonGroupManager>(*param, paramGroupId);
-        
+        mButtonState = std::make_unique<RadioButtonGroupManager> (*param, paramGroupId);
+
         for (const auto button : mButtons)
         {
-            mButtonState->attach(button);
+            mButtonState->attach (button);
         }
     }
 }
@@ -76,40 +76,39 @@ void FlatTextChooser::paint (juce::Graphics& g)
 void FlatTextChooser::resized()
 {
     const auto mainArea = getLocalBounds();
-    const auto margin = juce::roundToInt(mainArea.getHeight() * .01f);
-    auto buttonArea = getLocalBounds().reduced(margin);
+    const auto margin = juce::roundToInt (mainArea.getHeight() * .01f);
+    auto buttonArea = getLocalBounds().reduced (margin);
 
-    const auto labelHeight = juce::roundToInt(buttonArea.getHeight() * .140);
-    const auto labelArea = buttonArea.removeFromTop(labelHeight);
+    const auto labelHeight = juce::roundToInt (buttonArea.getHeight() * .140);
+    const auto labelArea = buttonArea.removeFromTop (labelHeight);
 
-    mLabel.setBounds(labelArea);
+    mLabel.setBounds (labelArea);
 
     // Make some more space between label and buttons
-    buttonArea.removeFromTop(labelHeight);
+    buttonArea.removeFromTop (labelHeight);
 
     if (mAlignWithParameterSliders)
     {
-        buttonArea.removeFromBottom(buttonArea.getHeight() * .15f);
+        buttonArea.removeFromBottom (buttonArea.getHeight() * .15f);
     }
 
     // The buttons themselves shouldn't take up all of the horizontal space
     // given to this component
-    const auto sideMargin = juce::roundToInt(buttonArea.getHeight() * .6f);
-    buttonArea.reduce(sideMargin, 0);
+    const auto sideMargin = juce::roundToInt (buttonArea.getHeight() * .6f);
+    buttonArea.reduce (sideMargin, 0);
 
     const auto numButtons = mButtons.size();
     const auto buttonWidth = buttonArea.getWidth();
-    const auto buttonHeight = juce::roundToInt(buttonArea.getHeight() / static_cast<float>(numButtons));
+    const auto buttonHeight = juce::roundToInt (buttonArea.getHeight() / static_cast<float> (numButtons));
     const auto x = buttonArea.getX();
     auto y = buttonArea.getY();
 
     for (auto* button : mButtons)
     {
-        button->setBounds(x, y, buttonWidth, buttonHeight);
+        button->setBounds (x, y, buttonWidth, buttonHeight);
 
         y += buttonHeight;
     }
-
 }
 
 } // namespace tote_bag

--- a/libs/Common/GUI/Components/Widgets/FlatTextChooser.h
+++ b/libs/Common/GUI/Components/Widgets/FlatTextChooser.h
@@ -10,8 +10,8 @@
 
 #pragma once
 
-#include "Common/GUI/Managers/RadioButtonGroupManager.h"
 #include "Common/GUI/Components/Widgets/FlatTextButton.h"
+#include "Common/GUI/Managers/RadioButtonGroupManager.h"
 
 #include <juce_gui_basics/juce_gui_basics.h>
 
@@ -26,21 +26,20 @@ namespace tote_bag
 {
 /*
 */
-class FlatTextChooser  : public juce::Component
+class FlatTextChooser : public juce::Component
 {
 public:
-    FlatTextChooser(const juce::String&,
-                    const std::vector<std::string>&,
-                    int,
-                    juce::AudioParameterChoice*,
-                    bool);
+    FlatTextChooser (const juce::String&,
+                     const std::vector<std::string>&,
+                     int,
+                     juce::AudioParameterChoice*,
+                     bool);
     ~FlatTextChooser() override;
 
     void paint (juce::Graphics&) override;
     void resized() override;
 
 private:
-    
     juce::Label mLabel;
 
     juce::OwnedArray<FlatTextButton> mButtons;

--- a/libs/Common/GUI/Components/Widgets/LabelSlider.cpp
+++ b/libs/Common/GUI/Components/Widgets/LabelSlider.cpp
@@ -14,16 +14,16 @@
 
 //==============================================================================
 
-LabelSlider::LabelSlider(const juce::String& parameterId,
-                         juce::AudioProcessorValueTreeState& stateToControl) :
-slider(parameterId, stateToControl)
+LabelSlider::LabelSlider (const juce::String& parameterId,
+                          juce::AudioProcessorValueTreeState& stateToControl)
+    : slider (parameterId, stateToControl)
 {
-    label.setText(stateToControl.getParameter(parameterId)->name, juce::dontSendNotification);
-    label.setColour(juce::Label::textColourId, juce::Colours::black);
-    label.setJustificationType(juce::Justification::centredTop);
+    label.setText (stateToControl.getParameter (parameterId)->name, juce::dontSendNotification);
+    label.setColour (juce::Label::textColourId, juce::Colours::black);
+    label.setJustificationType (juce::Justification::centredTop);
 
-    addAndMakeVisible(label);
-    addAndMakeVisible(slider);
+    addAndMakeVisible (label);
+    addAndMakeVisible (slider);
 }
 
 LabelSlider::~LabelSlider()
@@ -37,12 +37,12 @@ void LabelSlider::paint (juce::Graphics& g)
 void LabelSlider::resized()
 {
     const auto mainArea = getLocalBounds();
-    const auto margin = juce::roundToInt(mainArea.getHeight() * .01f);
-    auto sliderArea = mainArea.reduced(margin);
+    const auto margin = juce::roundToInt (mainArea.getHeight() * .01f);
+    auto sliderArea = mainArea.reduced (margin);
 
-    const auto labelHeight = juce::roundToInt(sliderArea.getHeight() * .140);
-    const auto labelArea = sliderArea.removeFromTop(labelHeight);
+    const auto labelHeight = juce::roundToInt (sliderArea.getHeight() * .140);
+    const auto labelArea = sliderArea.removeFromTop (labelHeight);
 
-    slider.setBounds(sliderArea);
-    label.setBounds(labelArea);
+    slider.setBounds (sliderArea);
+    label.setBounds (labelArea);
 }

--- a/libs/Common/GUI/Components/Widgets/LabelSlider.h
+++ b/libs/Common/GUI/Components/Widgets/LabelSlider.h
@@ -20,14 +20,13 @@
 namespace juce
 {
 class AudioProcessorValueTreeState;
-}// namespace juce
+} // namespace juce
 
-class LabelSlider  : public juce::Component
+class LabelSlider : public juce::Component
 {
 public:
-
-    LabelSlider(const juce::String& parameterId,
-                juce::AudioProcessorValueTreeState& stateToControl);
+    LabelSlider (const juce::String& parameterId,
+                 juce::AudioProcessorValueTreeState& stateToControl);
 
     ~LabelSlider() override;
 

--- a/libs/Common/GUI/Components/Widgets/ParameterSlider.cpp
+++ b/libs/Common/GUI/Components/Widgets/ParameterSlider.cpp
@@ -10,13 +10,13 @@
 
 #include "ParameterSlider.h"
 
-ParameterSlider::ParameterSlider(const juce::String& parameterId,
-                                   juce::AudioProcessorValueTreeState& stateToControl) :
-sliderValue(std::make_unique<juce::AudioProcessorValueTreeState::SliderAttachment>(stateToControl,
-                                                                                   parameterId,
-                                                                                   *this))
+ParameterSlider::ParameterSlider (const juce::String& parameterId,
+                                  juce::AudioProcessorValueTreeState& stateToControl)
+    : sliderValue (std::make_unique<juce::AudioProcessorValueTreeState::SliderAttachment> (stateToControl,
+                                                                                           parameterId,
+                                                                                           *this))
 {
-    setSliderStyle(SliderStyle::RotaryHorizontalVerticalDrag);
-    setTextValueSuffix(stateToControl.getParameter(parameterId)->label);
-    setTextBoxStyle(Slider::TextEntryBoxPosition::TextBoxBelow, false, 0, 0);
+    setSliderStyle (SliderStyle::RotaryHorizontalVerticalDrag);
+    setTextValueSuffix (stateToControl.getParameter (parameterId)->label);
+    setTextBoxStyle (Slider::TextEntryBoxPosition::TextBoxBelow, false, 0, 0);
 }

--- a/libs/Common/GUI/Components/Widgets/ParameterSlider.h
+++ b/libs/Common/GUI/Components/Widgets/ParameterSlider.h
@@ -17,14 +17,11 @@
 class ParameterSlider : public juce::Slider
 {
 public:
-
     ParameterSlider (const juce::String& parameterId,
                      juce::AudioProcessorValueTreeState& stateToControl);
 
 private:
-
     std::unique_ptr<juce::AudioProcessorValueTreeState::SliderAttachment> sliderValue;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ParameterSlider)
 };
-

--- a/libs/Common/GUI/Components/Widgets/ParameterTextButton.cpp
+++ b/libs/Common/GUI/Components/Widgets/ParameterTextButton.cpp
@@ -12,10 +12,10 @@
 
 ParameterTextButton::ParameterTextButton (const juce::String& buttonText,
                                           const juce::String& parameterId,
-                                          juce::AudioProcessorValueTreeState& stateToControl) :
-buttonValue(stateToControl, parameterId, *this)
+                                          juce::AudioProcessorValueTreeState& stateToControl)
+    : buttonValue (stateToControl, parameterId, *this)
 {
-    setButtonText(buttonText);
+    setButtonText (buttonText);
     changeWidthToFitText();
     setClickingTogglesState (true);
 }

--- a/libs/Common/GUI/Components/Widgets/ParameterTextButton.h
+++ b/libs/Common/GUI/Components/Widgets/ParameterTextButton.h
@@ -10,8 +10,8 @@
 
 #pragma once
 
-#include <juce_gui_basics/juce_gui_basics.h>
 #include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
 class ParameterTextButton : public juce::TextButton
 {
@@ -22,6 +22,6 @@ public:
 
 private:
     juce::AudioProcessorValueTreeState::ButtonAttachment buttonValue;
-    
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ParameterTextButton)
 };

--- a/libs/Common/GUI/LookAndFeel/LookAndFeel.cpp
+++ b/libs/Common/GUI/LookAndFeel/LookAndFeel.cpp
@@ -33,29 +33,30 @@ LookAndFeel::LookAndFeel()
 
     setupDefaultMeterColours();
 
-    setDefaultLookAndFeel(this);
+    setDefaultLookAndFeel (this);
 
     // slider colours
-    setColour(ColourIds::knobColourId, juce::Colours::grey);
-    setColour(ColourIds::pointerColourId, juce::Colours::black);
+    setColour (ColourIds::knobColourId, juce::Colours::grey);
+    setColour (ColourIds::pointerColourId, juce::Colours::black);
 
     // slider text box colours
-    setColour(juce::Slider::textBoxTextColourId, juce::Colours::black);
-    setColour(juce::Slider::textBoxOutlineColourId, vPinkDark);
-    setColour(juce::Slider::rotarySliderOutlineColourId, vPinkDark);
-    setColour(juce::Slider::rotarySliderFillColourId, juce::Colours::floralwhite);
+    setColour (juce::Slider::textBoxTextColourId, juce::Colours::black);
+    setColour (juce::Slider::textBoxOutlineColourId, vPinkDark);
+    setColour (juce::Slider::rotarySliderOutlineColourId, vPinkDark);
+    setColour (juce::Slider::rotarySliderFillColourId, juce::Colours::floralwhite);
 }
 
-void LookAndFeel::drawSliderMeter(juce::Graphics& g,
+void LookAndFeel::drawSliderMeter (juce::Graphics& g,
                                    const juce::Rectangle<float> bounds,
                                    const float lineWidth,
                                    const float radius,
-                                   const float startAngle, float endAngle,
+                                   const float startAngle,
+                                   float endAngle,
                                    const float toAngle,
-                                  juce::Slider& slider)
+                                   juce::Slider& slider)
 {
     auto outline = slider.findColour (juce::Slider::rotarySliderOutlineColourId);
-    auto fill    = slider.findColour (juce::Slider::rotarySliderFillColourId);
+    auto fill = slider.findColour (juce::Slider::rotarySliderFillColourId);
 
     juce::Path backgroundArc;
     backgroundArc.addCentredArc (bounds.getCentreX(),
@@ -93,31 +94,32 @@ void LookAndFeel::drawSliderMeter(juce::Graphics& g,
     }
 }
 
-void LookAndFeel::drawDrawableKnob(juce::Graphics& g,
-                                   const float radius,
-                                   const float drawableWidth,
-                                   juce::Drawable& sliderImage,
-                                   const float toAngle,
-                                   const juce::Rectangle<float> bounds)
+void LookAndFeel::drawDrawableKnob (juce::Graphics& g,
+                                    const float radius,
+                                    const float drawableWidth,
+                                    juce::Drawable& sliderImage,
+                                    const float toAngle,
+                                    const juce::Rectangle<float> bounds)
 {
     const auto rw = radius * 2.0f;
     const auto realW = rw / drawableWidth;
 
     const auto halfDrawableWidth = drawableWidth / 2.0f;
 
-    sliderImage.setTransform(juce::AffineTransform::rotation(toAngle,
-                                                             halfDrawableWidth,
-                                                             halfDrawableWidth).scaled(realW,
-                                                                                       realW,
-                                                                                       halfDrawableWidth,
-                                                                                       halfDrawableWidth));
+    sliderImage.setTransform (juce::AffineTransform::rotation (toAngle,
+                                                               halfDrawableWidth,
+                                                               halfDrawableWidth)
+                                  .scaled (realW,
+                                           realW,
+                                           halfDrawableWidth,
+                                           halfDrawableWidth));
 
     const auto cX = bounds.getCentreX() - halfDrawableWidth;
     const auto cY = bounds.getCentreY() - halfDrawableWidth;
-    sliderImage.drawAt(g, cX, cY, 1.0f);
+    sliderImage.drawAt (g, cX, cY, 1.0f);
 }
 
-void LookAndFeel::drawKnob(juce::Graphics& g,
+void LookAndFeel::drawKnob (juce::Graphics& g,
                             const float radius,
                             const float toAngle,
                             const juce::Rectangle<float> bounds,
@@ -132,12 +134,12 @@ void LookAndFeel::drawKnob(juce::Graphics& g,
     auto rw = radius * 2.0f;
 
     // Fill main knob area
-    auto fillColour = findColour(ColourIds::knobColourId);
+    auto fillColour = findColour (ColourIds::knobColourId);
     g.setColour (fillColour);
     g.fillEllipse (rx, ry, rw, rw);
 
     // Get thicknesses for outline rings...
-    const auto innerOutlineThickness = juce::jmax((rw * .05f), 1.0f);
+    const auto innerOutlineThickness = juce::jmax ((rw * .05f), 1.0f);
     const auto outerOutlineThickness = innerOutlineThickness * .15f;
 
     // Offset inner outline by its thickness
@@ -147,7 +149,7 @@ void LookAndFeel::drawKnob(juce::Graphics& g,
     auto innerOutlineRw = innerOutlineRadius * 2.0f;
 
     // Draw inner outline
-    g.setColour (fillColour.darker(.15f));
+    g.setColour (fillColour.darker (.15f));
     g.drawEllipse (innerOutlineRx, innerOutlineRy, innerOutlineRw, innerOutlineRw, innerOutlineThickness);
 
     // Offset outer outline by its thickness
@@ -159,20 +161,19 @@ void LookAndFeel::drawKnob(juce::Graphics& g,
     // Draw outer outline
     if (withDropShadow)
     {
+        auto xOffset = juce::jmin (juce::roundToInt (innerOutlineThickness * .25), 1);
+        auto yOffset = juce::jmin (juce::roundToInt (innerOutlineThickness * .5), 1);
 
-        auto xOffset = juce::jmin(juce::roundToInt(innerOutlineThickness * .25), 1);
-        auto yOffset = juce::jmin(juce::roundToInt(innerOutlineThickness * .5), 1);
-
-        auto shadow = juce::DropShadow(fillColour.darker(),
-                                       innerOutlineThickness,
-                                       {xOffset, yOffset});
+        auto shadow = juce::DropShadow (fillColour.darker(),
+                                        innerOutlineThickness,
+                                        { xOffset, yOffset });
         juce::Path shadowPath;
-        shadowPath.addEllipse(outerOutlineRx, outerOutlineRy, outerOutlineRw, outerOutlineRw);
-        shadow.drawForPath(g, shadowPath);
+        shadowPath.addEllipse (outerOutlineRx, outerOutlineRy, outerOutlineRw, outerOutlineRw);
+        shadow.drawForPath (g, shadowPath);
     }
     else
     {
-        g.setColour (fillColour.darker(.85f));
+        g.setColour (fillColour.darker (.85f));
         g.drawEllipse (outerOutlineRx, outerOutlineRy, outerOutlineRw, outerOutlineRw, outerOutlineThickness);
     }
 
@@ -181,39 +182,37 @@ void LookAndFeel::drawKnob(juce::Graphics& g,
     auto pointerLength = radius * 0.33f;
     auto pointerThickness = pointerLength * .2f;
     auto cornerSize = pointerThickness * .35f;
-    p.addRoundedRectangle(-pointerThickness * 0.5f, -radius + innerOutlineThickness,
-                          pointerThickness, pointerLength,
-                          cornerSize, cornerSize,
-                          true, true,
-                          false, false);
+    p.addRoundedRectangle (-pointerThickness * 0.5f, -radius + innerOutlineThickness, pointerThickness, pointerLength, cornerSize, cornerSize, true, true, false, false);
     p.applyTransform (juce::AffineTransform::rotation (toAngle).translated (bounds.getCentreX(), bounds.getCentreY()));
 
-    auto pointerColour = findColour(ColourIds::pointerColourId);
+    auto pointerColour = findColour (ColourIds::pointerColourId);
     g.setColour (pointerColour);
     g.fillPath (p);
 }
 
 void LookAndFeel::drawRotarySlider (juce::Graphics& g,
-                                    int x, int y,
-                                    int width, int height,
+                                    int x,
+                                    int y,
+                                    int width,
+                                    int height,
                                     float sliderPos,
-                                    const float rotaryStartAngle, const float rotaryEndAngle,
+                                    const float rotaryStartAngle,
+                                    const float rotaryEndAngle,
                                     juce::Slider& slider)
 {
-
     auto bounds = juce::Rectangle<int> (x, y, width, height).toFloat().reduced (10);
     auto radius = juce::jmin (bounds.getWidth(), bounds.getHeight()) / 2.0f;
     auto lineW = radius * 0.125f;
     auto arcRadius = radius - lineW * 0.5f;
     const auto toAngle = rotaryStartAngle + sliderPos * (rotaryEndAngle - rotaryStartAngle);
 
-    drawSliderMeter(g, bounds, lineW, arcRadius, rotaryStartAngle, rotaryEndAngle, toAngle, slider);
+    drawSliderMeter (g, bounds, lineW, arcRadius, rotaryStartAngle, rotaryEndAngle, toAngle, slider);
 
     const auto knobRadius = arcRadius * .80f;
 
-    drawKnob(g, knobRadius, toAngle, bounds, slider, true);
+    drawKnob (g, knobRadius, toAngle, bounds, slider, true);
 }
-        
+
 //=============================================================================
 
 juce::Typeface::Ptr LookAndFeel::getTypefaceForFont (const juce::Font& f)
@@ -223,29 +222,29 @@ juce::Typeface::Ptr LookAndFeel::getTypefaceForFont (const juce::Font& f)
 
 juce::Font LookAndFeel::getTextButtonFont (juce::TextButton& b, int buttonHeight)
 {
-    return  {juce::jmax (7.0f, buttonHeight * 0.8f)};
+    return { juce::jmax (7.0f, buttonHeight * 0.8f) };
 }
-    
+
 juce::Font LookAndFeel::getLabelFont (juce::Label& l)
 {
-    return { static_cast<float>(l.getHeight()) };
+    return { static_cast<float> (l.getHeight()) };
 }
-    
-    void LookAndFeel::drawButtonBackground (juce::Graphics& g,
-                                            juce::Button& button,
-                                            const juce::Colour& backgroundColour,
-                                            bool,
-                                            bool isButtonDown)
-    {
-        auto buttonArea = button.getLocalBounds();
-        const auto h = buttonArea.getHeight();
 
-        const auto cornerSize = h * .15;
+void LookAndFeel::drawButtonBackground (juce::Graphics& g,
+                                        juce::Button& button,
+                                        const juce::Colour& backgroundColour,
+                                        bool,
+                                        bool isButtonDown)
+{
+    auto buttonArea = button.getLocalBounds();
+    const auto h = buttonArea.getHeight();
 
-        g.setColour(backgroundColour);
+    const auto cornerSize = h * .15;
 
-        g.fillRoundedRectangle(buttonArea.toFloat(), cornerSize);
-    }
+    g.setColour (backgroundColour);
+
+    g.fillRoundedRectangle (buttonArea.toFloat(), cornerSize);
+}
 
 void LookAndFeel::drawFlatButtonBackground (juce::Graphics& g,
                                             tote_bag::FlatTextButton& button,
@@ -255,32 +254,26 @@ void LookAndFeel::drawFlatButtonBackground (juce::Graphics& g,
 {
     auto bounds = button.getLocalBounds().toFloat();
 
-    auto r = juce::jmin(bounds.getWidth(), bounds.getHeight());
+    auto r = juce::jmin (bounds.getWidth(), bounds.getHeight());
     auto cornerSize = r * .5f;
 
     auto baseColour = backgroundColour.withMultipliedSaturation (button.hasKeyboardFocus (true) ? 1.3f : 0.9f)
-                                      .withMultipliedAlpha (button.isEnabled() ? 1.0f : 0.5f);
+                          .withMultipliedAlpha (button.isEnabled() ? 1.0f : 0.5f);
 
     if (shouldDrawButtonAsDown || shouldDrawButtonAsHighlighted)
         baseColour = baseColour.contrasting (shouldDrawButtonAsDown ? 0.2f : 0.05f);
 
     g.setColour (baseColour);
 
-    auto flatOnLeft   = button.isConnectedOnLeft();
-    auto flatOnRight  = button.isConnectedOnRight();
-    auto flatOnTop    = button.isConnectedOnTop();
+    auto flatOnLeft = button.isConnectedOnLeft();
+    auto flatOnRight = button.isConnectedOnRight();
+    auto flatOnTop = button.isConnectedOnTop();
     auto flatOnBottom = button.isConnectedOnBottom();
 
     if (flatOnLeft || flatOnRight || flatOnTop || flatOnBottom)
     {
         juce::Path path;
-        path.addRoundedRectangle (bounds.getX(), bounds.getY(),
-                                  bounds.getWidth(), bounds.getHeight(),
-                                  cornerSize, cornerSize,
-                                  ! (flatOnLeft  || flatOnTop),
-                                  ! (flatOnRight || flatOnTop),
-                                  ! (flatOnLeft  || flatOnBottom),
-                                  ! (flatOnRight || flatOnBottom));
+        path.addRoundedRectangle (bounds.getX(), bounds.getY(), bounds.getWidth(), bounds.getHeight(), cornerSize, cornerSize, !(flatOnLeft || flatOnTop), !(flatOnRight || flatOnTop), !(flatOnLeft || flatOnBottom), !(flatOnRight || flatOnBottom));
 
         g.fillPath (path);
     }
@@ -290,160 +283,169 @@ void LookAndFeel::drawFlatButtonBackground (juce::Graphics& g,
     }
 }
 
-    void LookAndFeel::drawButtonText (juce::Graphics& g,
-                                      juce::TextButton& button,
-                                      bool,
-                                      bool isButtonDown)
+void LookAndFeel::drawButtonText (juce::Graphics& g,
+                                  juce::TextButton& button,
+                                  bool,
+                                  bool isButtonDown)
+{
+    auto font = getTextButtonFont (button, button.getHeight());
+    g.setFont (font);
+    g.setColour (button.findColour (isButtonDown ? juce::TextButton::textColourOnId
+                                                 : juce::TextButton::textColourOffId)
+                     .withMultipliedAlpha (button.isEnabled() ? 1.0f : 0.5f));
+
+    auto yIndent = juce::jmin (4, button.proportionOfHeight (0.5f));
+    auto cornerSize = juce::jmin (button.getHeight(), button.getWidth()) / 2;
+
+    auto fontHeight = juce::roundToInt (font.getHeight() * 0.6f);
+    auto leftIndent = juce::jmin (fontHeight, 2 + cornerSize / (button.isConnectedOnLeft() ? 4 : 2));
+    auto rightIndent = juce::jmin (fontHeight, 2 + cornerSize / (button.isConnectedOnRight() ? 4 : 2));
+    auto textWidth = button.getWidth() - leftIndent - rightIndent;
+
+    //auto edge = 4;
+    //auto offset = isButtonDown ? edge / 2 : 0;
+
+    if (textWidth > 0)
+        g.drawFittedText (button.getButtonText(),
+                          leftIndent,
+                          yIndent,
+                          textWidth,
+                          button.getHeight() - yIndent * 2,
+                          juce::Justification::centred,
+                          2);
+}
+
+void LookAndFeel::drawComboBox (juce::Graphics& g,
+                                int width,
+                                int height,
+                                bool,
+                                int,
+                                int,
+                                int,
+                                int,
+                                juce::ComboBox& box)
+{
+    const auto boxBounds = box.getLocalBounds();
+
+    const auto fontHeight = juce::jmax (7.0f, height * 0.6f);
+    g.setFont (juce::Font (fontHeight));
+
+    g.setColour (box.findColour (juce::ComboBox::backgroundColourId));
+
+    const auto h = boxBounds.getHeight();
+    const auto cornerSize = h * .15f;
+    g.fillRoundedRectangle (boxBounds.toFloat(), cornerSize);
+}
+
+void LookAndFeel::drawPopupMenuItem (juce::Graphics& g,
+                                     const juce::Rectangle<int>& area,
+                                     bool isSeparator,
+                                     bool isActive,
+                                     bool isHighlighted,
+                                     bool isTicked,
+                                     bool hasSubMenu,
+                                     const juce::String& text,
+                                     const juce::String& shortcutKeyText,
+                                     const juce::Drawable* icon,
+                                     const juce::Colour* textColour)
+{
+    using namespace laf_constants;
+
+    juce::Rectangle<int> r (area);
+
+    juce::Colour fillColour = isHighlighted ? vColour_5 : vColour_4;
+    g.setColour (fillColour);
+    g.fillRect (r.getX(), r.getY(), r.getWidth(), r.getHeight() - 1);
+
+    juce::Colour myTextColour = isTicked ? vColour_7 : vColour_1;
+    g.setColour (myTextColour);
+
+    auto fHeight = juce::jmax (7.0f, r.getHeight() * 0.6f);
+    g.setFont (juce::Font (fHeight));
+
+    r.setLeft (10);
+    r.setY (1);
+    g.drawFittedText (text, r, juce::Justification::left, 1);
+}
+
+juce::Slider::SliderLayout LookAndFeel::getSliderLayout (juce::Slider& slider)
+{
+    // 1. compute the actually visible textBox size from the slider textBox size and some additional constraints
+
+    int minXSpace = 0;
+    int minYSpace = 0;
+
+    auto textBoxPos = slider.getTextBoxPosition();
+
+    if (textBoxPos == juce::Slider::TextBoxLeft || textBoxPos == juce::Slider::TextBoxRight)
+        minXSpace = 30;
+    else
+        minYSpace = 15;
+
+    auto localBounds = slider.getLocalBounds();
+
+    auto sDiameter = juce::jmin (localBounds.getWidth(), localBounds.getHeight()) - 4.0f;
+    auto textBoxWidth = sDiameter * .66f;
+    auto textBoxHeight = sDiameter * .17f;
+
+    juce::Slider::SliderLayout layout;
+
+    // 2. set the textBox bounds
+
+    if (textBoxPos != juce::Slider::NoTextBox)
     {
-        auto font = getTextButtonFont (button, button.getHeight());
-        g.setFont (font);
-        g.setColour (button.findColour (isButtonDown ? juce::TextButton::textColourOnId
-                                                     : juce::TextButton::textColourOffId)
-                           .withMultipliedAlpha (button.isEnabled() ? 1.0f : 0.5f));
-
-        auto yIndent = juce::jmin (4, button.proportionOfHeight (0.5f));
-        auto cornerSize = juce::jmin (button.getHeight(), button.getWidth()) / 2;
-
-        auto fontHeight = juce::roundToInt (font.getHeight() * 0.6f);
-        auto leftIndent  = juce::jmin (fontHeight, 2 + cornerSize / (button.isConnectedOnLeft()  ? 4 : 2));
-        auto rightIndent = juce::jmin (fontHeight, 2 + cornerSize / (button.isConnectedOnRight() ? 4 : 2));
-        auto textWidth = button.getWidth() - leftIndent - rightIndent;
-
-        //auto edge = 4;
-        //auto offset = isButtonDown ? edge / 2 : 0;
-
-        if (textWidth > 0)
-            g.drawFittedText (button.getButtonText(),
-                              leftIndent, yIndent,
-                              textWidth, button.getHeight() - yIndent * 2,
-                              juce::Justification::centred, 2);
-    }
-
-    void LookAndFeel::drawComboBox (juce::Graphics& g,
-                                    int width, int height,
-                                    bool,
-                                    int, int, int, int,
-                                    juce::ComboBox& box)
-    {
-        const auto boxBounds = box.getLocalBounds();
-
-        const auto fontHeight = juce::jmax (7.0f, height * 0.6f);
-        g.setFont(juce::Font(fontHeight));
-
-        g.setColour (box.findColour (juce::ComboBox::backgroundColourId));
-
-        const auto h = boxBounds.getHeight();
-        const auto cornerSize = h * .15f;
-        g.fillRoundedRectangle(boxBounds.toFloat(), cornerSize);
-    }
-
-    void LookAndFeel::drawPopupMenuItem (juce::Graphics& g,
-                                         const juce::Rectangle<int>& area,
-                                         bool isSeparator,
-                                         bool isActive,
-                                         bool isHighlighted,
-                                         bool isTicked,
-                                         bool hasSubMenu,
-                                         const juce::String& text,
-                                         const juce::String& shortcutKeyText,
-                                         const juce::Drawable* icon,
-                                         const juce::Colour* textColour)
-      {
-          using namespace laf_constants;
-
-          juce::Rectangle<int> r (area);
-
-          juce::Colour fillColour = isHighlighted ? vColour_5 : vColour_4;
-          g.setColour(fillColour);
-          g.fillRect(r.getX(), r.getY(), r.getWidth(), r.getHeight() - 1 );
-
-          juce::Colour myTextColour = isTicked ? vColour_7 : vColour_1;
-          g.setColour(myTextColour);
-
-          auto fHeight = juce::jmax (7.0f, r.getHeight() * 0.6f);
-          g.setFont(juce::Font(fHeight));
-
-          r.setLeft(10);
-          r.setY(1);
-          g.drawFittedText(text, r, juce::Justification::left, 1);
-
-      }
-    
-    
-    
-    juce::Slider::SliderLayout LookAndFeel::getSliderLayout (juce::Slider& slider)
-    {
-        // 1. compute the actually visible textBox size from the slider textBox size and some additional constraints
-
-        int minXSpace = 0;
-        int minYSpace = 0;
-
-        auto textBoxPos = slider.getTextBoxPosition();
-
-        if (textBoxPos == juce::Slider::TextBoxLeft || textBoxPos == juce::Slider::TextBoxRight)
-            minXSpace = 30;
-        else
-            minYSpace = 15;
-
-        auto localBounds = slider.getLocalBounds();
-
-        
-        auto sDiameter = juce::jmin(localBounds.getWidth(), localBounds.getHeight()) - 4.0f;
-        auto textBoxWidth  = sDiameter * .66f;
-        auto textBoxHeight = sDiameter * .17f;
-      
-        juce::Slider::SliderLayout layout;
-
-        // 2. set the textBox bounds
-
-        if (textBoxPos != juce::Slider::NoTextBox)
-        {
-            if (slider.isBar())
-            {
-                layout.textBoxBounds = localBounds;
-            }
-            else
-            {
-                layout.textBoxBounds.setWidth (textBoxWidth);
-                layout.textBoxBounds.setHeight (textBoxHeight);
-
-                if (textBoxPos == juce::Slider::TextBoxLeft)           layout.textBoxBounds.setX (0);
-                else if (textBoxPos == juce::Slider::TextBoxRight)     layout.textBoxBounds.setX (localBounds.getWidth() - textBoxWidth);
-                else /* above or below -> centre horizontally */ layout.textBoxBounds.setX ((localBounds.getWidth() - textBoxWidth) / 2);
-
-                if (textBoxPos == juce::Slider::TextBoxAbove)          layout.textBoxBounds.setY (0);
-                else if (textBoxPos == juce::Slider::TextBoxBelow)     layout.textBoxBounds.setY (localBounds.getHeight() - textBoxHeight);
-                else /* left or right -> centre vertically */    layout.textBoxBounds.setY ((localBounds.getHeight() - textBoxHeight) / 2);
-            }
-        }
-
-        // 3. set the slider bounds
-
-        layout.sliderBounds = localBounds;
-
         if (slider.isBar())
         {
-            layout.sliderBounds.reduce (1, 1);   // bar border
+            layout.textBoxBounds = localBounds;
         }
         else
         {
-            if (textBoxPos == juce::Slider::TextBoxLeft)       layout.sliderBounds.removeFromLeft (textBoxWidth);
-            else if (textBoxPos == juce::Slider::TextBoxRight) layout.sliderBounds.removeFromRight (textBoxWidth);
-            else if (textBoxPos == juce::Slider::TextBoxAbove) layout.sliderBounds.removeFromTop (textBoxHeight);
-            else if (textBoxPos == juce::Slider::TextBoxBelow) layout.sliderBounds.removeFromBottom (textBoxHeight);
+            layout.textBoxBounds.setWidth (textBoxWidth);
+            layout.textBoxBounds.setHeight (textBoxHeight);
 
-            const int thumbIndent = getSliderThumbRadius (slider);
+            if (textBoxPos == juce::Slider::TextBoxLeft)
+                layout.textBoxBounds.setX (0);
+            else if (textBoxPos == juce::Slider::TextBoxRight)
+                layout.textBoxBounds.setX (localBounds.getWidth() - textBoxWidth);
+            else /* above or below -> centre horizontally */
+                layout.textBoxBounds.setX ((localBounds.getWidth() - textBoxWidth) / 2);
 
-            if (slider.isHorizontal())    layout.sliderBounds.reduce (thumbIndent, 0);
-            else if (slider.isVertical()) layout.sliderBounds.reduce (0, thumbIndent);
+            if (textBoxPos == juce::Slider::TextBoxAbove)
+                layout.textBoxBounds.setY (0);
+            else if (textBoxPos == juce::Slider::TextBoxBelow)
+                layout.textBoxBounds.setY (localBounds.getHeight() - textBoxHeight);
+            else /* left or right -> centre vertically */
+                layout.textBoxBounds.setY ((localBounds.getHeight() - textBoxHeight) / 2);
         }
-
-        return layout;
     }
+
+    // 3. set the slider bounds
+
+    layout.sliderBounds = localBounds;
+
+    if (slider.isBar())
+    {
+        layout.sliderBounds.reduce (1, 1); // bar border
+    }
+    else
+    {
+        if (textBoxPos == juce::Slider::TextBoxLeft)
+            layout.sliderBounds.removeFromLeft (textBoxWidth);
+        else if (textBoxPos == juce::Slider::TextBoxRight)
+            layout.sliderBounds.removeFromRight (textBoxWidth);
+        else if (textBoxPos == juce::Slider::TextBoxAbove)
+            layout.sliderBounds.removeFromTop (textBoxHeight);
+        else if (textBoxPos == juce::Slider::TextBoxBelow)
+            layout.sliderBounds.removeFromBottom (textBoxHeight);
+
+        const int thumbIndent = getSliderThumbRadius (slider);
+
+        if (slider.isHorizontal())
+            layout.sliderBounds.reduce (thumbIndent, 0);
+        else if (slider.isVertical())
+            layout.sliderBounds.reduce (0, thumbIndent);
+    }
+
+    return layout;
+}
 } // namespace tote_bag
-
-    
-    
-    
-    
-

--- a/libs/Common/GUI/LookAndFeel/LookAndFeel.h
+++ b/libs/Common/GUI/LookAndFeel/LookAndFeel.h
@@ -10,28 +10,28 @@
 
 #pragma once
 
-#include <juce_gui_basics/juce_gui_basics.h>
 #include <ff_meters/ff_meters.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 
 namespace tote_bag
 {
 class FlatTextButton;
 
 class LookAndFeel : public juce::LookAndFeel_V4,
-                     public FFAU::LevelMeter::LookAndFeelMethods
+                    public FFAU::LevelMeter::LookAndFeelMethods
 {
-    
 public:
     LookAndFeel();
 
-    void drawSliderMeter(juce::Graphics& g,
-                         const juce::Rectangle<float> bounds,
-                         float lineWidth,
-                         float arcRadius,
-                         float rotaryStartAngle, float rotaryEndAngle,
-                         float toAngle,
-                         juce::Slider& slider);
-    
+    void drawSliderMeter (juce::Graphics& g,
+                          const juce::Rectangle<float> bounds,
+                          float lineWidth,
+                          float arcRadius,
+                          float rotaryStartAngle,
+                          float rotaryEndAngle,
+                          float toAngle,
+                          juce::Slider& slider);
+
     /** Draws a drawable knob. Originally used for the knobs in Valentine, this is been refactored
         to not rely on member variables. This, along with the fact that this function isn't called
         anywhere, effectively orphans it. This is intentional: the way that the drawable was defined
@@ -39,25 +39,28 @@ public:
 
         TODO: Refactor slider drawing to effectively use this function if desired
      */
-    void drawDrawableKnob(juce::Graphics& g,
-                          const float radius,
-                          const float drawableWidth,
-                          juce::Drawable& sliderImage,
-                          const float toAngle,
-                          const juce::Rectangle<float> bounds);
+    void drawDrawableKnob (juce::Graphics& g,
+                           const float radius,
+                           const float drawableWidth,
+                           juce::Drawable& sliderImage,
+                           const float toAngle,
+                           const juce::Rectangle<float> bounds);
 
-    void drawKnob(juce::Graphics& g,
-                  const float radius,
-                  const float toAngle,
-                  const juce::Rectangle<float> bounds,
-                  juce::Slider& slider,
-                  const bool withDropShadow);
+    void drawKnob (juce::Graphics& g,
+                   const float radius,
+                   const float toAngle,
+                   const juce::Rectangle<float> bounds,
+                   juce::Slider& slider,
+                   const bool withDropShadow);
 
     void drawRotarySlider (juce::Graphics& g,
-                           int x, int y,
-                           int width, int height,
+                           int x,
+                           int y,
+                           int width,
+                           int height,
                            float sliderPos,
-                           const float rotaryStartAngle, const float rotaryEndAngle,
+                           const float rotaryStartAngle,
+                           const float rotaryEndAngle,
                            juce::Slider&) override;
 
     juce::Typeface::Ptr getTypefaceForFont (const juce::Font& f) override;
@@ -71,23 +74,28 @@ public:
                                const juce::Colour& backgroundColour,
                                bool,
                                bool isButtonDown) override;
-    
+
     void drawFlatButtonBackground (juce::Graphics& g,
                                    tote_bag::FlatTextButton& button,
                                    const juce::Colour& backgroundColour,
                                    bool,
                                    bool isButtonDown);
-    
+
     void drawButtonText (juce::Graphics& g,
                          juce::TextButton& button,
                          bool,
                          bool isButtonDown) override;
-    
+
     void drawComboBox (juce::Graphics& g,
-                       int width, int height,
-                       bool, int, int, int, int,
+                       int width,
+                       int height,
+                       bool,
+                       int,
+                       int,
+                       int,
+                       int,
                        juce::ComboBox& box) override;
-    
+
     void drawPopupMenuItem (juce::Graphics& g,
                             const juce::Rectangle<int>& area,
                             bool isSeparator,
@@ -99,13 +107,12 @@ public:
                             const juce::String& shortcutKeyText,
                             const juce::Drawable* icon,
                             const juce::Colour* textColour) override;
-    
+
     juce::Slider::SliderLayout getSliderLayout (juce::Slider& slider) override;
-    
-    enum ColourIds
-    {
-      knobColourId = 0x1001800,
-      pointerColourId = 0x1001801
+
+    enum ColourIds {
+        knobColourId = 0x1001800,
+        pointerColourId = 0x1001801
     };
 
 #include "MeterLookAndFeelMethods.h"

--- a/libs/Common/GUI/LookAndFeel/LookAndFeelConstants.h
+++ b/libs/Common/GUI/LookAndFeel/LookAndFeelConstants.h
@@ -23,12 +23,12 @@ const juce::Colour vGreen2 (0xff83a028);
 const juce::Colour vRed (0xffef202a);
 const juce::Colour vYellow (0xffffce00);
 
-const juce::Colour vColour_1 = juce::Colour(105,105,105);
-const juce::Colour vColour_2 = juce::Colour(0,0,0).withAlpha(0.0f);
-const juce::Colour vColour_3 = juce::Colour(0,0,0).withAlpha(0.3f);
-const juce::Colour vColour_4 = juce::Colour(0,0,0).withAlpha(0.6f);
-const juce::Colour vColour_5 = juce::Colour(105,105,105).withAlpha(0.3f);
-const juce::Colour vColour_6 = juce::Colour(0,0,0).withAlpha(0.8f);
-const juce::Colour vColour_7 = juce::Colour(125,125,125);
+const juce::Colour vColour_1 = juce::Colour (105, 105, 105);
+const juce::Colour vColour_2 = juce::Colour (0, 0, 0).withAlpha (0.0f);
+const juce::Colour vColour_3 = juce::Colour (0, 0, 0).withAlpha (0.3f);
+const juce::Colour vColour_4 = juce::Colour (0, 0, 0).withAlpha (0.6f);
+const juce::Colour vColour_5 = juce::Colour (105, 105, 105).withAlpha (0.3f);
+const juce::Colour vColour_6 = juce::Colour (0, 0, 0).withAlpha (0.8f);
+const juce::Colour vColour_7 = juce::Colour (125, 125, 125);
 } // laf_constants
 } // tote_bag

--- a/libs/Common/GUI/LookAndFeel/MeterLookAndFeelMethods.h
+++ b/libs/Common/GUI/LookAndFeel/MeterLookAndFeelMethods.h
@@ -10,28 +10,28 @@
 
 #pragma once
 
-void setupDefaultMeterColours () override
+void setupDefaultMeterColours() override
 {
-    setColour (FFAU::LevelMeter::lmTextColour,             juce::Colours::black);
-    setColour (FFAU::LevelMeter::lmTextClipColour,         juce::Colours::white);
-    setColour (FFAU::LevelMeter::lmTextDeactiveColour,     juce::Colours::darkgrey);
-    setColour (FFAU::LevelMeter::lmTicksColour,            juce::Colours::orange);
-    setColour (FFAU::LevelMeter::lmOutlineColour,          juce::Colours::orange);
-    setColour (FFAU::LevelMeter::lmBackgroundColour,       juce::Colours::lightpink);
-    setColour (FFAU::LevelMeter::lmBackgroundClipColour,   juce::Colours::red);
-    setColour (FFAU::LevelMeter::lmMeterForegroundColour,  juce::Colours::green);
-    setColour (FFAU::LevelMeter::lmMeterOutlineColour,     juce::Colours::lightgrey);
-    setColour (FFAU::LevelMeter::lmMeterBackgroundColour,  juce::Colours::darkgrey);
-    setColour (FFAU::LevelMeter::lmMeterMaxNormalColour,   juce::Colours::lightgrey);
-    setColour (FFAU::LevelMeter::lmMeterMaxWarnColour,     juce::Colours::orange);
-    setColour (FFAU::LevelMeter::lmMeterMaxOverColour,     juce::Colours::darkred);
+    setColour (FFAU::LevelMeter::lmTextColour, juce::Colours::black);
+    setColour (FFAU::LevelMeter::lmTextClipColour, juce::Colours::white);
+    setColour (FFAU::LevelMeter::lmTextDeactiveColour, juce::Colours::darkgrey);
+    setColour (FFAU::LevelMeter::lmTicksColour, juce::Colours::orange);
+    setColour (FFAU::LevelMeter::lmOutlineColour, juce::Colours::orange);
+    setColour (FFAU::LevelMeter::lmBackgroundColour, juce::Colours::lightpink);
+    setColour (FFAU::LevelMeter::lmBackgroundClipColour, juce::Colours::red);
+    setColour (FFAU::LevelMeter::lmMeterForegroundColour, juce::Colours::green);
+    setColour (FFAU::LevelMeter::lmMeterOutlineColour, juce::Colours::lightgrey);
+    setColour (FFAU::LevelMeter::lmMeterBackgroundColour, juce::Colours::darkgrey);
+    setColour (FFAU::LevelMeter::lmMeterMaxNormalColour, juce::Colours::lightgrey);
+    setColour (FFAU::LevelMeter::lmMeterMaxWarnColour, juce::Colours::orange);
+    setColour (FFAU::LevelMeter::lmMeterMaxOverColour, juce::Colours::darkred);
     setColour (FFAU::LevelMeter::lmMeterGradientLowColour, juce::Colours::green);
     setColour (FFAU::LevelMeter::lmMeterGradientMidColour, juce::Colours::lightgoldenrodyellow);
     setColour (FFAU::LevelMeter::lmMeterGradientMaxColour, juce::Colours::red);
-    setColour (FFAU::LevelMeter::lmMeterReductionColour,   juce::Colours::orange);
+    setColour (FFAU::LevelMeter::lmMeterReductionColour, juce::Colours::orange);
 }
 
-void updateMeterGradients () override
+void updateMeterGradients() override
 {
     horizontalGradient.clearColours();
     verticalGradient.clearColours();
@@ -40,7 +40,8 @@ void updateMeterGradients () override
 juce::Rectangle<float> getMeterInnerBounds (const juce::Rectangle<float> bounds,
                                             const FFAU::LevelMeter::MeterFlags meterType) const override
 {
-    if (meterType & FFAU::LevelMeter::HasBorder) {
+    if (meterType & FFAU::LevelMeter::HasBorder)
+    {
         const float corner = std::min (bounds.getWidth(), bounds.getHeight()) * 0.01f;
         return bounds.reduced (3 + corner);
     }
@@ -52,72 +53,80 @@ juce::Rectangle<float> getMeterBounds (const juce::Rectangle<float> bounds,
                                        const int numChannels,
                                        const int channel) const override
 {
-    if (meterType & FFAU::LevelMeter::SingleChannel) {
+    if (meterType & FFAU::LevelMeter::SingleChannel)
+    {
         return bounds;
     }
-    else {
-        if (meterType & FFAU::LevelMeter::Horizontal) {
+    else
+    {
+        if (meterType & FFAU::LevelMeter::Horizontal)
+        {
             const float h = bounds.getHeight() / numChannels;
             return bounds.withHeight (h).withY (bounds.getY() + channel * h);
         }
-        else {
+        else
+        {
             const float w = bounds.getWidth() / numChannels;
-            return bounds.withWidth (w).withX (bounds.getX() + channel  );
+            return bounds.withWidth (w).withX (bounds.getX() + channel);
         }
     }
-    return juce::Rectangle<float> ();
+    return juce::Rectangle<float>();
 }
 
 /** Override this callback to define the placement of the actual meter bar. */
 juce::Rectangle<float> getMeterBarBounds (const juce::Rectangle<float> bounds,
                                           const FFAU::LevelMeter::MeterFlags meterType) const override
 {
-    
     if (meterType & FFAU::LevelMeter::Minimal
-        || meterType & FFAU::LevelMeter::Reduction) {
-        if (meterType & FFAU::LevelMeter::Horizontal) {
+        || meterType & FFAU::LevelMeter::Reduction)
+    {
+        if (meterType & FFAU::LevelMeter::Horizontal)
+        {
             const float margin = bounds.getHeight() * 0.05f;
-            const float h      = bounds.getHeight() - 2.0f * margin;
-            const float left   = bounds.getX() + margin;
-            const float right  = bounds.getRight() - (4.0f * margin + h);
-            return juce::Rectangle<float>(bounds.getX() + margin,
-                                          bounds.getY() + margin,
-                                          right - left,
-                                          h);
+            const float h = bounds.getHeight() - 2.0f * margin;
+            const float left = bounds.getX() + margin;
+            const float right = bounds.getRight() - (4.0f * margin + h);
+            return juce::Rectangle<float> (bounds.getX() + margin,
+                                           bounds.getY() + margin,
+                                           right - left,
+                                           h);
         }
-        else {
+        else
+        {
             const float margin = bounds.getHeight() * 0.001f;
-            const float top    = bounds.getY() + 2.0f * margin;
-            const float bottom = (meterType & FFAU::LevelMeter::MaxNumber) ?
-                                  bounds.getBottom() - (3.0f * margin + ((bounds.getHeight() * .1) - margin * 2.0f))
-                                  : bounds.getBottom() - margin;
-            return juce::Rectangle<float>(bounds.getX() + margin, top,
-                                          bounds.getWidth() - margin * 2.0f, bottom - top);
+            const float top = bounds.getY() + 2.0f * margin;
+            const float bottom = (meterType & FFAU::LevelMeter::MaxNumber) ? bounds.getBottom() - (3.0f * margin + ((bounds.getHeight() * .1) - margin * 2.0f))
+                                                                           : bounds.getBottom() - margin;
+            return juce::Rectangle<float> (bounds.getX() + margin, top, bounds.getWidth() - margin * 2.0f, bottom - top);
         }
     }
-    else if (meterType & FFAU::LevelMeter::Vintage) {
+    else if (meterType & FFAU::LevelMeter::Vintage)
+    {
         return bounds;
     }
-    else {
-        if (meterType & FFAU::LevelMeter::Horizontal) {
+    else
+    {
+        if (meterType & FFAU::LevelMeter::Horizontal)
+        {
             const float margin = bounds.getHeight() * 0.05f;
-            const float h      = bounds.getHeight() * 0.5f - 2.0f * margin;
-            const float left   = 60.0f + 3.0f * margin;
-            const float right  = bounds.getRight() - (4.0f * margin + h * 0.5f);
-            return juce::Rectangle<float>(bounds.getX() + left,
-                                          bounds.getY() + margin,
-                                          right - left,
-                                          h);
+            const float h = bounds.getHeight() * 0.5f - 2.0f * margin;
+            const float left = 60.0f + 3.0f * margin;
+            const float right = bounds.getRight() - (4.0f * margin + h * 0.5f);
+            return juce::Rectangle<float> (bounds.getX() + left,
+                                           bounds.getY() + margin,
+                                           right - left,
+                                           h);
         }
-        else {
+        else
+        {
             const float margin = bounds.getWidth() * 0.05f;
-            const float w      = bounds.getWidth() * 0.45f;
-            const float top    = bounds.getY() + 2.0f * margin + w * 0.5f;
+            const float w = bounds.getWidth() * 0.45f;
+            const float top = bounds.getY() + 2.0f * margin + w * 0.5f;
             const float bottom = bounds.getBottom() - (2.0f * margin + 25.0f);
-            return juce::Rectangle<float>(bounds.getX() + margin, top, w, bottom - top);
+            return juce::Rectangle<float> (bounds.getX() + margin, top, w, bottom - top);
         }
     }
-    return juce::Rectangle<float> ();
+    return juce::Rectangle<float>();
 }
 
 /** Override this callback to define the placement of the tickmarks.
@@ -125,7 +134,7 @@ juce::Rectangle<float> getMeterBarBounds (const juce::Rectangle<float> bounds,
 juce::Rectangle<float> getMeterTickmarksBounds (const juce::Rectangle<float> bounds,
                                                 const FFAU::LevelMeter::MeterFlags meterType) const override
 {
-    return juce::Rectangle<float> ();
+    return juce::Rectangle<float>();
 }
 
 /** Override this callback to define the placement of the clip indicator light.
@@ -133,7 +142,7 @@ juce::Rectangle<float> getMeterTickmarksBounds (const juce::Rectangle<float> bou
 juce::Rectangle<float> getMeterClipIndicatorBounds (const juce::Rectangle<float> bounds,
                                                     const FFAU::LevelMeter::MeterFlags meterType) const override
 {
-    return juce::Rectangle<float> ();
+    return juce::Rectangle<float>();
 }
 
 /** Override this callback to define the placement of the max level.
@@ -142,26 +151,33 @@ juce::Rectangle<float> getMeterMaxNumberBounds (const juce::Rectangle<float> bou
                                                 const FFAU::LevelMeter::MeterFlags meterType) const override
 {
     if (meterType & FFAU::LevelMeter::Minimal
-        || meterType & FFAU::LevelMeter::Reduction) {
-        if (meterType & FFAU::LevelMeter::MaxNumber) {
-            if (meterType & FFAU::LevelMeter::Horizontal) {
+        || meterType & FFAU::LevelMeter::Reduction)
+    {
+        if (meterType & FFAU::LevelMeter::MaxNumber)
+        {
+            if (meterType & FFAU::LevelMeter::Horizontal)
+            {
                 const float margin = bounds.getHeight() * 0.05f;
-                const float h      = bounds.getHeight() - 2.0f * margin;
-                return juce::Rectangle<float>(bounds.getRight() - (margin + h),
-                                              bounds.getY() + margin,
-                                              h, h);
+                const float h = bounds.getHeight() - 2.0f * margin;
+                return juce::Rectangle<float> (bounds.getRight() - (margin + h),
+                                               bounds.getY() + margin,
+                                               h,
+                                               h);
             }
-            else {
+            else
+            {
                 const float margin = bounds.getWidth() * 0.02f;
-                const float w      = bounds.getWidth() - margin * 2.0f;
-                const float h      = bounds.getHeight() * 0.085f;
-                return juce::Rectangle<float>(bounds.getX() + margin,
-                                              bounds.getBottom() - (margin + (h * 1.5f)),
-                                              w, h);
+                const float w = bounds.getWidth() - margin * 2.0f;
+                const float h = bounds.getHeight() * 0.085f;
+                return juce::Rectangle<float> (bounds.getX() + margin,
+                                               bounds.getBottom() - (margin + (h * 1.5f)),
+                                               w,
+                                               h);
             }
         }
-        else {
-            return juce::Rectangle<float> ();
+        else
+        {
+            return juce::Rectangle<float>();
         }
     }
     return juce::Rectangle<float>();
@@ -172,14 +188,16 @@ juce::Rectangle<float> drawBackground (juce::Graphics& g,
                                        const juce::Rectangle<float> bounds) override
 {
     g.setColour (findColour (FFAU::LevelMeter::lmBackgroundColour));
-    if (meterType & FFAU::LevelMeter::HasBorder) {
+    if (meterType & FFAU::LevelMeter::HasBorder)
+    {
         const float corner = std::min (bounds.getWidth(), bounds.getHeight()) * 0.01f;
         g.fillRoundedRectangle (bounds, corner);
         g.setColour (findColour (FFAU::LevelMeter::lmOutlineColour));
         g.drawRoundedRectangle (bounds.reduced (3), corner, 2);
         return bounds.reduced (3 + corner);
     }
-    else {
+    else
+    {
         g.fillRect (bounds);
         return bounds;
     }
@@ -189,96 +207,94 @@ void drawMeterBars (juce::Graphics& g,
                     const FFAU::LevelMeter::MeterFlags meterType,
                     const juce::Rectangle<float> bounds,
                     const FFAU::LevelMeterSource* source,
-                    const int fixedNumChannels=-1,
-                    const int selectedChannel=-1) override
+                    const int fixedNumChannels = -1,
+                    const int selectedChannel = -1) override
 {
     const juce::Rectangle<float> innerBounds = getMeterInnerBounds (bounds, meterType);
-    if (source) {
+    if (source)
+    {
         const int numChannels = source->getNumChannels();
-        if (meterType & FFAU::LevelMeter::Minimal) {
-            if (meterType & FFAU::LevelMeter::Horizontal) {
+        if (meterType & FFAU::LevelMeter::Minimal)
+        {
+            if (meterType & FFAU::LevelMeter::Horizontal)
+            {
                 const float height = innerBounds.getHeight() / (2 * numChannels - 1);
                 juce::Rectangle<float> meter = innerBounds.withHeight (height);
-                for (int channel=0; channel < numChannels; ++channel) {
+                for (int channel = 0; channel < numChannels; ++channel)
+                {
                     meter.setY (height * channel * 2);
                     {
                         juce::Rectangle<float> meterBarBounds = getMeterBarBounds (meter, meterType);
-                        drawMeterBar (g, meterType, meterBarBounds,
-                                      source->getRMSLevel (channel),
-                                      source->getMaxLevel (channel));
+                        drawMeterBar (g, meterType, meterBarBounds, source->getRMSLevel (channel), source->getMaxLevel (channel));
                         const float reduction = source->getReductionLevel (channel);
                         if (reduction < 1.0)
-                            drawMeterReduction (g, meterType,
-                                                meterBarBounds.withBottom (meterBarBounds.getCentreY()),
-                                                reduction);
+                            drawMeterReduction (g, meterType, meterBarBounds.withBottom (meterBarBounds.getCentreY()), reduction);
                     }
                     juce::Rectangle<float> clip = getMeterClipIndicatorBounds (meter, meterType);
-                    if (! clip.isEmpty())
+                    if (!clip.isEmpty())
                         drawClipIndicator (g, meterType, clip, source->getClipFlag (channel));
                     juce::Rectangle<float> maxNum = getMeterMaxNumberBounds (meter, meterType);
-                    if (! maxNum.isEmpty())
-                        drawMaxNumber(g, meterType, maxNum, source->getMaxOverallLevel (channel));
-                    if (channel < numChannels-1) {
+                    if (!maxNum.isEmpty())
+                        drawMaxNumber (g, meterType, maxNum, source->getMaxOverallLevel (channel));
+                    if (channel < numChannels - 1)
+                    {
                         meter.setY (height * (channel * 2 + 1));
                         juce::Rectangle<float> ticks = getMeterTickmarksBounds (meter, meterType);
-                        if (! ticks.isEmpty())
+                        if (!ticks.isEmpty())
                             drawTickMarks (g, meterType, ticks);
                     }
                 }
             }
-            else {
-                const float width = innerBounds.getWidth() / numChannels ;
-                for (int channel=0; channel < numChannels; ++channel) {
-                    juce::Rectangle<float> meter = innerBounds.withWidth(width);
+            else
+            {
+                const float width = innerBounds.getWidth() / numChannels;
+                for (int channel = 0; channel < numChannels; ++channel)
+                {
+                    juce::Rectangle<float> meter = innerBounds.withWidth (width);
                     meter.setX (width * channel);
                     juce::Rectangle<float> clip = getMeterClipIndicatorBounds (meter, meterType);
-                    if (! clip.isEmpty())
+                    if (!clip.isEmpty())
                     {
-                        meter.removeFromTop(clip.getHeight());
+                        meter.removeFromTop (clip.getHeight());
                         drawClipIndicator (g, meterType, clip, source->getClipFlag (channel));
                     }
-                    
+
                     {
                         juce::Rectangle<float> meterBarBounds = getMeterBarBounds (meter, meterType);
-                        drawMeterBar (g, meterType,
-                                      meterBarBounds,
-                                      source->getRMSLevel (channel),
-                                      source->getMaxLevel (channel));
+                        drawMeterBar (g, meterType, meterBarBounds, source->getRMSLevel (channel), source->getMaxLevel (channel));
                         const float reduction = source->getReductionLevel (channel);
                         if (reduction < 1.0)
-                            drawMeterReduction (g, meterType,
-                                                meterBarBounds.withLeft (meterBarBounds.getCentreX()),
-                                                reduction);
+                            drawMeterReduction (g, meterType, meterBarBounds.withLeft (meterBarBounds.getCentreX()), reduction);
                     }
                     juce::Rectangle<float> maxNum = getMeterMaxNumberBounds (innerBounds.withWidth (innerBounds.getWidth() / numChannels).withX (innerBounds.getX() + channel * (innerBounds.getWidth() / numChannels)), meterType);
-                    if (! maxNum.isEmpty()) {
-                        g.setColour(juce::Colours::cornflowerblue);
-                        g.fillRect(maxNum);
-                        drawMaxNumber(g, meterType, maxNum, source->getMaxLevel(channel));
+                    if (!maxNum.isEmpty())
+                    {
+                        g.setColour (juce::Colours::cornflowerblue);
+                        g.fillRect (maxNum);
+                        drawMaxNumber (g, meterType, maxNum, source->getMaxLevel (channel));
                     }
-                    if (channel < numChannels-1) {
+                    if (channel < numChannels - 1)
+                    {
                         meter.setX (width * (channel * 2 + 1));
                         juce::Rectangle<float> ticks = getMeterTickmarksBounds (meter, meterType);
-                        if (! ticks.isEmpty())
+                        if (!ticks.isEmpty())
                             drawTickMarks (g, meterType, ticks);
                     }
                 }
             }
         }
-        else if (meterType & FFAU::LevelMeter::Reduction) {
-        
+        else if (meterType & FFAU::LevelMeter::Reduction)
+        {
             const float width = innerBounds.getWidth() / numChannels;
-                   
-            juce::Rectangle<float> meter = innerBounds.withWidth(width);
-                
-            for (int channel=0; channel < numChannels; ++channel) {
-                drawMeterBar (g, meterType,
-                              getMeterBarBounds (meter, meterType),
-                              source->getReductionLevel(channel),
-                              0.0f);
-                
+
+            juce::Rectangle<float> meter = innerBounds.withWidth (width);
+
+            for (int channel = 0; channel < numChannels; ++channel)
+            {
+                drawMeterBar (g, meterType, getMeterBarBounds (meter, meterType), source->getReductionLevel (channel), 0.0f);
+
                 juce::Rectangle<float> maxes = getMeterMaxNumberBounds (bounds, meterType);
-                if (! maxes.isEmpty())
+                if (!maxes.isEmpty())
                 {
                     drawMaxNumber (g, meterType, maxes, source->getReductionLevel (channel));
                 }
@@ -294,72 +310,77 @@ void drawMeterBarsBackground (juce::Graphics& g,
                               const int fixedNumChannels) override
 {
     const juce::Rectangle<float> innerBounds = getMeterInnerBounds (bounds, meterType);
-    if (meterType & FFAU::LevelMeter::Minimal) {
-        if (meterType & FFAU::LevelMeter::Horizontal) {
+    if (meterType & FFAU::LevelMeter::Minimal)
+    {
+        if (meterType & FFAU::LevelMeter::Horizontal)
+        {
             const float height = innerBounds.getHeight() / (2 * numChannels - 1);
             juce::Rectangle<float> meter = innerBounds.withHeight (height);
-            for (int channel=0; channel < numChannels; ++channel) {
+            for (int channel = 0; channel < numChannels; ++channel)
+            {
                 meter.setY (height * channel * 2);
                 drawMeterBarBackground (g, meterType, getMeterBarBounds (meter, meterType));
                 juce::Rectangle<float> clip = getMeterClipIndicatorBounds (meter, meterType);
-                if (! clip.isEmpty())
+                if (!clip.isEmpty())
                     drawClipIndicatorBackground (g, meterType, clip);
-                if (channel < numChannels-1) {
+                if (channel < numChannels - 1)
+                {
                     meter.setY (height * (channel * 2 + 1));
                     juce::Rectangle<float> ticks = getMeterTickmarksBounds (meter, meterType);
-                    if (! ticks.isEmpty())
+                    if (!ticks.isEmpty())
                         drawTickMarks (g, meterType, ticks);
                 }
             }
         }
-        else {
-            for (int channel=0; channel < numChannels; ++channel) {
+        else
+        {
+            for (int channel = 0; channel < numChannels; ++channel)
+            {
                 const float width = innerBounds.getWidth() / numChannels;
-                juce::Rectangle<float> meter = innerBounds.withWidth(width);
+                juce::Rectangle<float> meter = innerBounds.withWidth (width);
                 meter.setX (width * channel);
-                
+
                 const juce::Rectangle<float> clip = getMeterClipIndicatorBounds (meter, meterType);
-                
-                if (! clip.isEmpty())
+
+                if (!clip.isEmpty())
                 {
                     drawClipIndicatorBackground (g, meterType, clip);
-                    meter.removeFromTop(clip.getHeight());
+                    meter.removeFromTop (clip.getHeight());
                 }
-                
+
                 drawMeterBarBackground (g, meterType, getMeterBarBounds (meter, meterType));
-                
-                if (channel < numChannels-1) {
+
+                if (channel < numChannels - 1)
+                {
                     meter.setX (width * (channel * 2 + 1));
                     juce::Rectangle<float> ticks = getMeterTickmarksBounds (meter, meterType);
-                    if (! ticks.isEmpty())
+                    if (!ticks.isEmpty())
                         drawTickMarks (g, meterType, ticks);
                 }
             }
         }
     }
-    else if (meterType & FFAU::LevelMeter::SingleChannel) {
+    else if (meterType & FFAU::LevelMeter::SingleChannel)
+    {
         drawMeterChannelBackground (g, meterType, innerBounds);
     }
-    else if (meterType & FFAU::LevelMeter::Reduction) {
-    
-    const float width = innerBounds.getWidth() / numChannels;
-           
-    juce::Rectangle<float> meter = innerBounds.withWidth(width);
-    meter.removeFromTop (getMeterClipIndicatorBounds (meter, FFAU::LevelMeter::MeterFlags::Minimal).getHeight());
-        
-    drawMeterBarBackground (g, meterType, getMeterBarBounds (meter, meterType));
-        
+    else if (meterType & FFAU::LevelMeter::Reduction)
+    {
+        const float width = innerBounds.getWidth() / numChannels;
+
+        juce::Rectangle<float> meter = innerBounds.withWidth (width);
+        meter.removeFromTop (getMeterClipIndicatorBounds (meter, FFAU::LevelMeter::MeterFlags::Minimal).getHeight());
+
+        drawMeterBarBackground (g, meterType, getMeterBarBounds (meter, meterType));
     }
-    else {
-        for (int channel=0; channel < numChannels; ++channel) {
-            drawMeterChannelBackground (g, meterType,
-                                        getMeterBounds (innerBounds, meterType,
-                                                        fixedNumChannels < 0 ? numChannels : fixedNumChannels,
-                                                        channel));
+    else
+    {
+        for (int channel = 0; channel < numChannels; ++channel)
+        {
+            drawMeterChannelBackground (g, meterType, getMeterBounds (innerBounds, meterType, fixedNumChannels < 0 ? numChannels : fixedNumChannels, channel));
         }
     }
 }
-
 
 void drawMeterChannel (juce::Graphics& g,
                        const FFAU::LevelMeter::MeterFlags meterType,
@@ -374,17 +395,19 @@ void drawMeterChannelBackground (juce::Graphics& g,
                                  const juce::Rectangle<float> bounds) override
 {
     juce::Rectangle<float> meter = getMeterBarBounds (bounds, meterType);
-    if (! meter.isEmpty()) {
+    if (!meter.isEmpty())
+    {
         drawMeterBarBackground (g, meterType, meter);
     }
     juce::Rectangle<float> clip = getMeterClipIndicatorBounds (bounds, meterType);
-    if (! clip.isEmpty())
+    if (!clip.isEmpty())
         drawClipIndicatorBackground (g, meterType, clip);
     juce::Rectangle<float> ticks = getMeterTickmarksBounds (bounds, meterType);
-    if (! ticks.isEmpty())
+    if (!ticks.isEmpty())
         drawTickMarks (g, meterType, ticks);
     juce::Rectangle<float> maxes = getMeterMaxNumberBounds (bounds, meterType);
-    if (! maxes.isEmpty()) {
+    if (!maxes.isEmpty())
+    {
         drawMaxNumberBackground (g, meterType, maxes);
     }
 }
@@ -392,70 +415,82 @@ void drawMeterChannelBackground (juce::Graphics& g,
 void drawMeterBar (juce::Graphics& g,
                    const FFAU::LevelMeter::MeterFlags meterType,
                    const juce::Rectangle<float> bounds,
-                   const float rms, const float peak) override
+                   const float rms,
+                   const float peak) override
 {
-    const float infinity = meterType & FFAU::LevelMeter::Reduction ? -30.0f :  -80.0f;
-    const float rmsDb  = juce::Decibels::gainToDecibels (rms,  infinity);
+    const float infinity = meterType & FFAU::LevelMeter::Reduction ? -30.0f : -80.0f;
+    const float rmsDb = juce::Decibels::gainToDecibels (rms, infinity);
     const float peakDb = juce::Decibels::gainToDecibels (peak, infinity);
 
-    const juce::Rectangle<float> floored (ceilf (bounds.getX()) + 1.0f, ceilf (bounds.getY()) + 1.0f,
-                                          floorf (bounds.getRight()) - (ceilf (bounds.getX() + 2.0f)),
-                                          floorf (bounds.getBottom()) - (ceilf (bounds.getY()) + 2.0f));
+    const juce::Rectangle<float> floored (ceilf (bounds.getX()) + 1.0f, ceilf (bounds.getY()) + 1.0f, floorf (bounds.getRight()) - (ceilf (bounds.getX() + 2.0f)), floorf (bounds.getBottom()) - (ceilf (bounds.getY()) + 2.0f));
 
-    if (meterType & FFAU::LevelMeter::Vintage) {
+    if (meterType & FFAU::LevelMeter::Vintage)
+    {
         // Vintage has not been implemented yet!!!
         jassertfalse;
     }
-    else if (meterType & FFAU::LevelMeter::Reduction) {
+    else if (meterType & FFAU::LevelMeter::Reduction)
+    {
         const float limitDb = juce::Decibels::gainToDecibels (rms, infinity);
         g.setColour (findColour (FFAU::LevelMeter::lmMeterReductionColour));
-        if (meterType & FFAU::LevelMeter::Horizontal) {
+        if (meterType & FFAU::LevelMeter::Horizontal)
+        {
             g.fillRect (floored.withLeft (floored.getX() + limitDb * floored.getWidth() / infinity));
         }
-        else {
+        else
+        {
             g.fillRect (floored.withBottom (floored.getY() + limitDb * floored.getHeight() / infinity));
         }
     }
-    else {
-        if (meterType & FFAU::LevelMeter::Horizontal) {
-            if (horizontalGradient.getNumColours() < 2) {
+    else
+    {
+        if (meterType & FFAU::LevelMeter::Horizontal)
+        {
+            if (horizontalGradient.getNumColours() < 2)
+            {
                 horizontalGradient = juce::ColourGradient (findColour (FFAU::LevelMeter::lmMeterGradientLowColour),
-                                                           floored.getX(), floored.getY(),
+                                                           floored.getX(),
+                                                           floored.getY(),
                                                            findColour (FFAU::LevelMeter::lmMeterGradientMaxColour),
-                                                           floored.getRight(), floored.getY(), false);
+                                                           floored.getRight(),
+                                                           floored.getY(),
+                                                           false);
                 horizontalGradient.addColour (0.5, findColour (FFAU::LevelMeter::lmMeterGradientLowColour));
                 horizontalGradient.addColour (0.75, findColour (FFAU::LevelMeter::lmMeterGradientMidColour));
             }
             g.setGradientFill (horizontalGradient);
             g.fillRect (floored.withRight (floored.getRight() - rmsDb * floored.getWidth() / infinity));
 
-            if (peakDb > -49.0) {
-                g.setColour (findColour ((peakDb > -0.3f) ? FFAU::LevelMeter::lmMeterMaxOverColour :
-                                         ((peakDb > -5.0) ? FFAU::LevelMeter::lmMeterMaxWarnColour :
-                                          FFAU::LevelMeter::lmMeterMaxNormalColour)));
-                g.drawVerticalLine (juce::roundToInt(floored.getRight() - juce::jmax (peakDb * floored.getWidth() / infinity, 0.0f)),
+            if (peakDb > -49.0)
+            {
+                g.setColour (findColour ((peakDb > -0.3f) ? FFAU::LevelMeter::lmMeterMaxOverColour : ((peakDb > -5.0) ? FFAU::LevelMeter::lmMeterMaxWarnColour : FFAU::LevelMeter::lmMeterMaxNormalColour)));
+                g.drawVerticalLine (juce::roundToInt (floored.getRight() - juce::jmax (peakDb * floored.getWidth() / infinity, 0.0f)),
                                     floored.getY(),
                                     floored.getBottom());
             }
         }
-        else {
+        else
+        {
             // vertical
-            if (verticalGradient.getNumColours() < 2) {
+            if (verticalGradient.getNumColours() < 2)
+            {
                 verticalGradient = juce::ColourGradient (findColour (FFAU::LevelMeter::lmMeterGradientLowColour),
-                                                         floored.getX(), floored.getBottom(),
+                                                         floored.getX(),
+                                                         floored.getBottom(),
                                                          findColour (FFAU::LevelMeter::lmMeterGradientMaxColour),
-                                                         floored.getX(), floored.getY(), false);
+                                                         floored.getX(),
+                                                         floored.getY(),
+                                                         false);
                 verticalGradient.addColour (0.5, findColour (FFAU::LevelMeter::lmMeterGradientLowColour));
                 verticalGradient.addColour (0.75, findColour (FFAU::LevelMeter::lmMeterGradientMidColour));
             }
             g.setGradientFill (verticalGradient);
             g.fillRect (floored.withTop (floored.getY() + rmsDb * floored.getHeight() / infinity));
 
-            if (peakDb > -49.0) {
-                g.setColour (findColour ((peakDb > -0.3f) ? FFAU::LevelMeter::lmMeterMaxOverColour :
-                                         ((peakDb > -5.0) ? FFAU::LevelMeter::lmMeterMaxWarnColour :
-                                          FFAU::LevelMeter::lmMeterMaxNormalColour)));
-                g.drawHorizontalLine (juce::roundToInt(floored.getY() + juce::jmax (peakDb * floored.getHeight() / infinity, 0.0f)),
+            if (peakDb > -49.0)
+            {
+                g.setColour (findColour ((peakDb > -0.3f) ? FFAU::LevelMeter::lmMeterMaxOverColour : ((peakDb > -5.0) ? FFAU::LevelMeter::lmMeterMaxWarnColour : FFAU::LevelMeter::lmMeterMaxNormalColour)));
+                g.drawHorizontalLine (juce::roundToInt (floored.getY() + juce::jmax (peakDb * floored.getHeight() / infinity, 0.0f)),
                                       floored.getX(),
                                       floored.getRight());
             }
@@ -469,17 +504,17 @@ void drawMeterReduction (juce::Graphics& g,
                          const float reduction) override
 {
     const float infinity = -30.0f;
-    
-    const juce::Rectangle<float> floored (ceilf (bounds.getX()) + 1.0f, ceilf (bounds.getY()) + 1.0f,
-                                          floorf (bounds.getRight()) - (ceilf (bounds.getX() + 2.0f)),
-                                          floorf (bounds.getBottom()) - (ceilf (bounds.getY()) + 2.0f));
+
+    const juce::Rectangle<float> floored (ceilf (bounds.getX()) + 1.0f, ceilf (bounds.getY()) + 1.0f, floorf (bounds.getRight()) - (ceilf (bounds.getX() + 2.0f)), floorf (bounds.getBottom()) - (ceilf (bounds.getY()) + 2.0f));
 
     const float limitDb = juce::Decibels::gainToDecibels (reduction, infinity);
     g.setColour (findColour (FFAU::LevelMeter::lmMeterReductionColour));
-    if (meterType & FFAU::LevelMeter::Horizontal) {
+    if (meterType & FFAU::LevelMeter::Horizontal)
+    {
         g.fillRect (floored.withLeft (floored.getX() + limitDb * floored.getWidth() / infinity));
     }
-    else {
+    else
+    {
         g.fillRect (floored.withBottom (floored.getY() + limitDb * floored.getHeight() / infinity));
     }
 }
@@ -489,76 +524,92 @@ void drawMeterBarBackground (juce::Graphics& g,
                              const juce::Rectangle<float> bounds) override
 {
     g.setColour (findColour (FFAU::LevelMeter::lmMeterBackgroundColour));
-    g.fillRect  (bounds);
+    g.fillRect (bounds);
 }
 
 void drawTickMarks (juce::Graphics& g,
                     const FFAU::LevelMeter::MeterFlags meterType,
                     const juce::Rectangle<float> bounds) override
 {
-    const float infinity = meterType & FFAU::LevelMeter::Reduction ? -30.0f :  -80.0f;
+    const float infinity = meterType & FFAU::LevelMeter::Reduction ? -30.0f : -80.0f;
 
     g.setColour (findColour (FFAU::LevelMeter::lmTicksColour));
-    if (meterType & FFAU::LevelMeter::Minimal) {
-        if (meterType & FFAU::LevelMeter::Horizontal) {
-            for (int i=0; i<11; ++i)
-                g.drawVerticalLine (juce::roundToInt(bounds.getX() + i * 0.1f * bounds.getWidth()),
+    if (meterType & FFAU::LevelMeter::Minimal)
+    {
+        if (meterType & FFAU::LevelMeter::Horizontal)
+        {
+            for (int i = 0; i < 11; ++i)
+                g.drawVerticalLine (juce::roundToInt (bounds.getX() + i * 0.1f * bounds.getWidth()),
                                     bounds.getY() + 4,
                                     bounds.getBottom() - 4);
         }
-        else {
+        else
+        {
             const float h = (bounds.getHeight() - 2.0f) * 0.1f;
-            for (int i=0; i<11; ++i) {
-                g.drawHorizontalLine (juce::roundToInt(bounds.getY() + i * h + 1),
+            for (int i = 0; i < 11; ++i)
+            {
+                g.drawHorizontalLine (juce::roundToInt (bounds.getY() + i * h + 1),
                                       bounds.getX() + 4,
                                       bounds.getRight());
             }
-            if (h > 10 && bounds.getWidth() > 20) {
+            if (h > 10 && bounds.getWidth() > 20)
+            {
                 // don't print tiny numbers
                 g.setFont (h * 0.5f);
-                for (int i=0; i<10; ++i) {
+                for (int i = 0; i < 10; ++i)
+                {
                     g.drawFittedText (juce::String (i * 0.1 * infinity),
-                                      juce::roundToInt(bounds.getX()),
-                                      juce::roundToInt(bounds.getY() + (float) i * h + 2.0f),
-                                      juce::roundToInt(bounds.getWidth()),
-                                      juce::roundToInt((float) h * 0.6f),
-                                      juce::Justification::centredTop, 1);
+                                      juce::roundToInt (bounds.getX()),
+                                      juce::roundToInt (bounds.getY() + (float) i * h + 2.0f),
+                                      juce::roundToInt (bounds.getWidth()),
+                                      juce::roundToInt ((float) h * 0.6f),
+                                      juce::Justification::centredTop,
+                                      1);
                 }
             }
         }
     }
-    else if (meterType & FFAU::LevelMeter::Vintage) {
+    else if (meterType & FFAU::LevelMeter::Vintage)
+    {
         // TODO
     }
-    else {
-        if (meterType & FFAU::LevelMeter::Horizontal) {
-            for (int i=0; i<11; ++i)
-                g.drawVerticalLine (juce::roundToInt(bounds.getX() + i * 0.1f * bounds.getWidth()),
+    else
+    {
+        if (meterType & FFAU::LevelMeter::Horizontal)
+        {
+            for (int i = 0; i < 11; ++i)
+                g.drawVerticalLine (juce::roundToInt (bounds.getX() + i * 0.1f * bounds.getWidth()),
                                     bounds.getY() + 4,
                                     bounds.getBottom() - 4);
         }
-        else {
+        else
+        {
             const float h = (bounds.getHeight() - 2.0f) * 0.05f;
             g.setFont (h * 0.8f);
-            for (int i=0; i<21; ++i) {
+            for (int i = 0; i < 21; ++i)
+            {
                 const float y = bounds.getY() + i * h;
-                if (i % 2 == 0) {
-                    g.drawHorizontalLine (juce::roundToInt(y + 1),
+                if (i % 2 == 0)
+                {
+                    g.drawHorizontalLine (juce::roundToInt (y + 1),
                                           bounds.getX() + 4,
                                           bounds.getRight());
-                    if (i < 20) {
+                    if (i < 20)
+                    {
                         g.drawFittedText (juce::String (i * 0.05f * infinity),
-                                          juce::roundToInt(bounds.getX()),
-                                          juce::roundToInt(y + 4),
-                                          juce::roundToInt(bounds.getWidth()),
-                                          juce::roundToInt(h * 0.6f),
-                                          juce::Justification::topRight, 1);
+                                          juce::roundToInt (bounds.getX()),
+                                          juce::roundToInt (y + 4),
+                                          juce::roundToInt (bounds.getWidth()),
+                                          juce::roundToInt (h * 0.6f),
+                                          juce::Justification::topRight,
+                                          1);
                     }
                 }
-                else {
-                  g.drawHorizontalLine (juce::roundToInt(y + 2),
-                                        bounds.getX() + 4,
-                                        bounds.getCentreX());
+                else
+                {
+                    g.drawHorizontalLine (juce::roundToInt (y + 2),
+                                          bounds.getX() + 4,
+                                          bounds.getCentreX());
                 }
             }
         }
@@ -589,14 +640,14 @@ void drawMaxNumber (juce::Graphics& g,
                     const juce::Rectangle<float> bounds,
                     const float maxGain) override
 {
-
     const float maxDb = juce::Decibels::gainToDecibels (maxGain, -80.0f);
     g.setColour (findColour (maxDb > 0.0 ? FFAU::LevelMeter::lmTextClipColour : FFAU::LevelMeter::lmTextColour));
     g.setFont (bounds.getHeight() * 0.5f);
-    
+
     g.drawFittedText (juce::String (maxDb, 1),
                       bounds.toNearestInt(),
-                      juce::Justification::centred, 1);
+                      juce::Justification::centred,
+                      1);
 }
 
 void drawMaxNumberBackground (juce::Graphics& g,
@@ -610,12 +661,14 @@ int hitTestClipIndicator (const juce::Point<int> position,
                           const juce::Rectangle<float> bounds,
                           const FFAU::LevelMeterSource* source) const override
 {
-    if (source) {
+    if (source)
+    {
         const int numChannels = source->getNumChannels();
-        for (int i=0; i < numChannels; ++i) {
-            if (getMeterClipIndicatorBounds (getMeterBounds
-                                             (bounds, meterType, source->getNumChannels(), i), meterType)
-                .contains (position.toFloat())) {
+        for (int i = 0; i < numChannels; ++i)
+        {
+            if (getMeterClipIndicatorBounds (getMeterBounds (bounds, meterType, source->getNumChannels(), i), meterType)
+                    .contains (position.toFloat()))
+            {
                 return i;
             }
         }
@@ -628,12 +681,14 @@ int hitTestMaxNumber (const juce::Point<int> position,
                       const juce::Rectangle<float> bounds,
                       const FFAU::LevelMeterSource* source) const override
 {
-    if (source) {
+    if (source)
+    {
         const int numChannels = source->getNumChannels();
-        for (int i=0; i < numChannels; ++i) {
-            if (getMeterMaxNumberBounds (getMeterBounds
-                                         (bounds, meterType, source->getNumChannels(), i), meterType)
-                .contains (position.toFloat())) {
+        for (int i = 0; i < numChannels; ++i)
+        {
+            if (getMeterMaxNumberBounds (getMeterBounds (bounds, meterType, source->getNumChannels(), i), meterType)
+                    .contains (position.toFloat()))
+            {
                 return i;
             }
         }
@@ -642,8 +697,5 @@ int hitTestMaxNumber (const juce::Point<int> position,
 }
 
 private:
-
 juce::ColourGradient horizontalGradient;
 juce::ColourGradient verticalGradient;
-
-

--- a/libs/Common/GUI/Managers/RadioButtonGroupManager.cpp
+++ b/libs/Common/GUI/Managers/RadioButtonGroupManager.cpp
@@ -15,13 +15,13 @@
 namespace tote_bag
 {
 
-RadioButtonGroupManager::RadioButtonGroupManager(juce::AudioParameterChoice& parameter, int groupId) :
-    mParameter(parameter)
-    ,mGroupId(groupId)
+RadioButtonGroupManager::RadioButtonGroupManager (juce::AudioParameterChoice& parameter, int groupId)
+    : mParameter (parameter)
+    , mGroupId (groupId)
 {
     mCurrentParameterIndex = mParameter.getIndex();
-    
-    startTimerHz(20);
+
+    startTimerHz (20);
 }
 
 RadioButtonGroupManager::~RadioButtonGroupManager()
@@ -33,31 +33,31 @@ RadioButtonGroupManager::~RadioButtonGroupManager()
     {
         button->onClick = nullptr;
     }
-    
+
     stopTimer();
 }
 
-void RadioButtonGroupManager::attach(juce::Button* button)
+void RadioButtonGroupManager::attach (juce::Button* button)
 {
     const auto index = mNextButtonIndex;
 
     button->onClick = [this, button, index] {
-        buttonOnClickCallback(button, index);
+        buttonOnClickCallback (button, index);
     };
 
     if (index == mCurrentParameterIndex)
     {
-        button->setToggleState(true, juce::dontSendNotification);
+        button->setToggleState (true, juce::dontSendNotification);
     }
 
-    button->setClickingTogglesState(true);
-    button->setRadioGroupId(mGroupId);
+    button->setClickingTogglesState (true);
+    button->setRadioGroupId (mGroupId);
 
-    mManagedButtons.emplace_back(button);
+    mManagedButtons.emplace_back (button);
     ++mNextButtonIndex;
 }
 
-void RadioButtonGroupManager::buttonOnClickCallback(juce::Button* button, int index)
+void RadioButtonGroupManager::buttonOnClickCallback (juce::Button* button, int index)
 {
     auto buttonOn = button->getToggleState();
 
@@ -65,10 +65,10 @@ void RadioButtonGroupManager::buttonOnClickCallback(juce::Button* button, int in
     {
         mCurrentParameterIndex = index;
 
-        const auto buttonVal = mParameter.convertTo0to1(index);
+        const auto buttonVal = mParameter.convertTo0to1 (index);
 
         mParameter.beginChangeGesture();
-        mParameter.setValueNotifyingHost(buttonVal);
+        mParameter.setValueNotifyingHost (buttonVal);
         mParameter.endChangeGesture();
     }
 }
@@ -76,10 +76,10 @@ void RadioButtonGroupManager::buttonOnClickCallback(juce::Button* button, int in
 void RadioButtonGroupManager::updateGroupState()
 {
     const auto parameterIndex = mParameter.getIndex();
-    if(mCurrentParameterIndex != parameterIndex)
+    if (mCurrentParameterIndex != parameterIndex)
     {
-        mManagedButtons[parameterIndex]->setToggleState(true,
-                                                   juce::dontSendNotification);
+        mManagedButtons[parameterIndex]->setToggleState (true,
+                                                         juce::dontSendNotification);
         mCurrentParameterIndex = parameterIndex;
     }
 }

--- a/libs/Common/GUI/Managers/RadioButtonGroupManager.h
+++ b/libs/Common/GUI/Managers/RadioButtonGroupManager.h
@@ -25,7 +25,7 @@ namespace tote_bag
 class RadioButtonGroupManager : public juce::Timer
 {
 public:
-    RadioButtonGroupManager(juce::AudioParameterChoice& parameter, int groupId);
+    RadioButtonGroupManager (juce::AudioParameterChoice& parameter, int groupId);
 
     ~RadioButtonGroupManager();
 
@@ -35,14 +35,13 @@ public:
         buttons managed by this class will be indexed in the order they
         were attached.
      */
-    void attach(juce::Button* button);
+    void attach (juce::Button* button);
 
 private:
-
     /** Called by a managed button's onClick() method to change button and
         parameter state.
      */
-    void buttonOnClickCallback(juce::Button* button, int index);
+    void buttonOnClickCallback (juce::Button* button, int index);
 
     /** Called periodically to check if param value has changed in a way not driven
         by a click on the button itself. e.g. via automation.
@@ -51,11 +50,11 @@ private:
 
     juce::AudioParameterChoice& mParameter;
     std::vector<juce::Button*> mManagedButtons;
-    int mGroupId {0};
-    int mCurrentParameterIndex {0};
-    int mNextButtonIndex {0};
+    int mGroupId { 0 };
+    int mCurrentParameterIndex { 0 };
+    int mNextButtonIndex { 0 };
 
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(RadioButtonGroupManager)
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (RadioButtonGroupManager)
 };
 } // namespace tote_bag
 

--- a/libs/Common/GUI/Managers/ToteBagPresetManager.cpp
+++ b/libs/Common/GUI/Managers/ToteBagPresetManager.cpp
@@ -12,83 +12,77 @@
 
 #include <juce_audio_processors/juce_audio_processors.h>
 
-
-
 ToteBagPresetManager::ToteBagPresetManager (juce::AudioProcessor* inProcessor)
-: processor (inProcessor)
+    : processor (inProcessor)
 {
     presetDirectory = juce::File ((juce::File::getSpecialLocation (juce::File::userDocumentsDirectory)).getFullPathName()
-                            + static_cast<std::string>(directorySeparator) + "Tote Bag"
-                            + static_cast<std::string>(directorySeparator) + processor->getName());
-    
+                                  + static_cast<std::string> (directorySeparator) + "Tote Bag"
+                                  + static_cast<std::string> (directorySeparator) + processor->getName());
+
     // checks if preset directory is there—if not, it creates the directory
-    if (! presetDirectory.exists())
+    if (!presetDirectory.exists())
         presetDirectory.createDirectory();
-        
+
     updatePresetList();
 }
 
 void ToteBagPresetManager::createNewPreset()
 {
-    
     auto& parameters = processor->getParameters();
-    
+
     for (int i = 0; i < parameters.size(); i++)
     {
-        auto parameter = (juce::AudioProcessorParameterWithID*) parameters.getUnchecked(i);
-        
+        auto parameter = (juce::AudioProcessorParameterWithID*) parameters.getUnchecked (i);
+
         const float defaultValue = parameter->getDefaultValue();
-        
+
         parameter->setValueNotifyingHost (defaultValue);
     }
-    
+
     currentPresetName = "Untitled";
 }
 
 void ToteBagPresetManager::savePreset (juce::File presetFile)
 {
-
     // check if the file passed in actually exists. if not, create it
-    if (! presetFile.exists())
+    if (!presetFile.exists())
         presetFile.create();
     else
         presetFile.deleteFile();
-    
+
     // update preset name for GUI display
     currentPresetName = presetFile.getFileNameWithoutExtension();
 
     // allocate memory on the stack, and fill it with our preset data
     juce::MemoryBlock destinationData;
     processor->getStateInformation (destinationData);
-    
+
     // write the preset data to file
-    presetFile.appendData(destinationData.getData(), static_cast<int> (destinationData.getSize()));
-    
+    presetFile.appendData (destinationData.getData(), static_cast<int> (destinationData.getSize()));
+
     updatePresetList();
 }
 
 void ToteBagPresetManager::loadPreset (juce::File presetToLoad)
 {
-    
     // if preset successfully loads, save its name and index
     juce::MemoryBlock presetBinary;
     if (presetToLoad.loadFileAsData (presetBinary))
     {
         currentPresetName = presetToLoad.getFileNameWithoutExtension();
-     
+
         // current preset name is set my set State Info
         processor->setStateInformation (presetBinary.getData(), static_cast<int> (presetBinary.getSize()));
     }
-    
 }
 
-void ToteBagPresetManager::loadPreset(int index)
+void ToteBagPresetManager::loadPreset (int index)
 {
     auto presetToLoad = juce::File (presetDirectory.getFullPathName()
-                              + static_cast<std::string>(directorySeparator)
-                              + getPresetName (index)
-                              + static_cast<std::string>(presetFileExtension));
-    loadPreset(presetToLoad);
+                                    + static_cast<std::string> (directorySeparator)
+                                    + getPresetName (index)
+                                    + static_cast<std::string> (presetFileExtension));
+    loadPreset (presetToLoad);
 }
 
 const juce::String ToteBagPresetManager::getPresetName (int inPresetIndex)
@@ -119,34 +113,32 @@ const juce::String ToteBagPresetManager::getCurrentPresetDirectory()
 void ToteBagPresetManager::setLastChosenPresetName (juce::String newPresetName)
 {
     currentPresetName = newPresetName;
-    mCurrentPresetIndex = findPresetIndex(currentPresetName);
+    mCurrentPresetIndex = findPresetIndex (currentPresetName);
 }
 
 void ToteBagPresetManager::updatePresetList()
 {
     presetList.clear();
-        
+
     auto directoryIterator = juce::RangedDirectoryIterator (juce::File (presetDirectory),
-                                                           false,
-                                                           static_cast<std::string>(presetFileExtensionWildcard),
-                                                           juce::File::TypesOfFileToFind::findFiles);
-        
+                                                            false,
+                                                            static_cast<std::string> (presetFileExtensionWildcard),
+                                                            juce::File::TypesOfFileToFind::findFiles);
+
     for (auto entry : directoryIterator)
         presetList.add (entry.getFile().getFileNameWithoutExtension());
 }
 
-int ToteBagPresetManager::findPresetIndex(const juce::String& presetName)
+int ToteBagPresetManager::findPresetIndex (const juce::String& presetName)
 {
-    const auto foundPreset = std::find(presetList.begin(),
-                                       presetList.end(),
-                                       presetName);
+    const auto foundPreset = std::find (presetList.begin(),
+                                        presetList.end(),
+                                        presetName);
 
-    if(foundPreset != presetList.end())
+    if (foundPreset != presetList.end())
     {
-        return static_cast<int>(foundPreset - presetList.begin());
+        return static_cast<int> (foundPreset - presetList.begin());
     }
 
     return 0;
 }
-
-

--- a/libs/Common/GUI/Managers/ToteBagPresetManager.h
+++ b/libs/Common/GUI/Managers/ToteBagPresetManager.h
@@ -12,7 +12,6 @@
 
 #include <juce_core/juce_core.h>
 
-
 namespace
 {
 constexpr std::string_view presetFileExtension = ".tbp";
@@ -32,7 +31,6 @@ class AudioProcessor;
 class ToteBagPresetManager
 {
 public:
-    
     ToteBagPresetManager (juce::AudioProcessor* inProcessor);
 
     /** Returns the number of presets loaded to the local presets array */
@@ -40,9 +38,9 @@ public:
 
     /** Sets all parameters to default and sets preset name to "Untitled"*/
     void createNewPreset();
-    
-    void savePreset(juce::File presetToSave);
-    
+
+    void savePreset (juce::File presetToSave);
+
     void loadPreset (juce::File presetToLoad);
 
     void loadPreset (int presetIndex);
@@ -58,23 +56,21 @@ public:
     const juce::String getCurrentPresetDirectory();
     /** Allows caller to set the name of the currently loaded preset. used to facilitate state restore */
     void setLastChosenPresetName (juce::String newPresetName);
-            
+
 private:
-    
     /** Iterates over the preset directory and adds the files to localPresets  */
     void updatePresetList();
 
-    int findPresetIndex(const juce::String& presetName);
-        
+    int findPresetIndex (const juce::String& presetName);
+
     juce::File presetDirectory;
-    juce::String currentPresetName {"Untitled"};
-    int mCurrentPresetIndex{0};
+    juce::String currentPresetName { "Untitled" };
+    int mCurrentPresetIndex { 0 };
     juce::Array<juce::String> presetList;
-    
+
     juce::AudioProcessor* processor;
-    
+
     bool presetIsDirty = false;
-    
-    
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ToteBagPresetManager)
 };

--- a/libs/Common/GUI/Utilities/GraphicsUtilities.cpp
+++ b/libs/Common/GUI/Utilities/GraphicsUtilities.cpp
@@ -13,26 +13,26 @@
 namespace gui_utils
 {
 
-void drawRoundedRect(juce::Graphics& g,
-                     juce::Rectangle<float> bounds,
-                     juce::Colour colour)
+void drawRoundedRect (juce::Graphics& g,
+                      juce::Rectangle<float> bounds,
+                      juce::Colour colour)
 {
     auto margin = bounds.getHeight() * .025f;
-    auto croppedBounds = bounds.reduced(margin);
+    auto croppedBounds = bounds.reduced (margin);
 
     auto h = croppedBounds.getHeight();
     auto lineThickness = h * .025f;
     auto cornerSize = h * .25;
 
-    g.setColour(colour.darker());
+    g.setColour (colour.darker());
 
-    g.drawRoundedRectangle(croppedBounds, cornerSize, lineThickness);
+    g.drawRoundedRectangle (croppedBounds, cornerSize, lineThickness);
 
-    g.setColour(colour);
+    g.setColour (colour);
 
     juce::Path p;
-    p.addRoundedRectangle(croppedBounds, cornerSize);
-    g.fillPath(p);
+    p.addRoundedRectangle (croppedBounds, cornerSize);
+    g.fillPath (p);
 }
 
 } // namespace gui_utils

--- a/libs/Common/GUI/Utilities/GraphicsUtilities.h
+++ b/libs/Common/GUI/Utilities/GraphicsUtilities.h
@@ -15,8 +15,8 @@
 namespace gui_utils
 {
 
-void drawRoundedRect(juce::Graphics& g,
-                     juce::Rectangle<float> bounds,
-                     juce::Colour colour);
+void drawRoundedRect (juce::Graphics& g,
+                      juce::Rectangle<float> bounds,
+                      juce::Colour colour);
 
 } // namespace gui_utils


### PR DESCRIPTION
The pamplejuce template came with a `.clang-format` file that
was pretty close to how I want things to look. And, after several
years of hacking away at this, things are a bit messy. So let's
clean it up!