### PR TITLE
Try bumping version to that found in slido fork

### DIFF
--- a/.github/workflows/cmake_ctest.yml
+++ b/.github/workflows/cmake_ctest.yml
@@ -75,7 +75,7 @@ jobs:
         key: v2-${{ matrix.os }}-${{ matrix.type }}
 
     - name: Import Certificates (macOS)
-      uses: apple-actions/import-codesign-certs@v1
+      uses: slidoapp/import-codesign-certs@v1.0.5
       if: ${{ matrix.name == 'macOS' }}
       with:
         p12-file-base64: ${{ secrets.DEV_ID_APP_CERT }}


### PR DESCRIPTION
The originating repo, `apple-actions`, hasn't been updated since October of last year.
In the meanwhile, fixes to issues and deprecations raised in `apple-actions` were merged
not to the main repo, but the `slidoapp` fork.