### PR TITLE
Handle codesign certificate download without the use of third party actions

### DIFF
--- a/.github/workflows/cmake_ctest.yml
+++ b/.github/workflows/cmake_ctest.yml
@@ -74,12 +74,37 @@ jobs:
       with:
         key: v2-${{ matrix.os }}-${{ matrix.type }}
 
-    - name: Import Certificates (macOS)
-      uses: tote-bag-labs/import-codesign-certs@253ddeeac23f2bdad1646faac5c8c2832e800071
+    - name: Setup Keychain and Import Signing Certificate
       if: ${{ matrix.name == 'macOS' }}
-      with:
-        p12-file-base64: ${{ secrets.DEV_ID_APP_CERT }}
-        p12-password: ${{ secrets.DEV_ID_APP_PASSWORD }}
+      shell: bash
+      env:
+        TEAM_ID: ${{ secrets.TEAM_ID }}
+        APP_SPECIFIC_PWD: ${{ secrets.NOTARIZATION_PASSWORD }}
+        CERT_PWD: ${{ secrets.DEV_ID_APP_PASSWORD }}
+        CERT_BASE64: ${{ secrets.DEV_ID_APP_CERT}}
+        CERTPATH: ${{ runner.temp }}/certificate.p12
+        KEYCHAINPWD: ${{ secrets.MACOS_CI_KEYCHAIN_PWD }}
+        KEYCHAINPATH: ${{ runner.temp }}/app-signing.keychain-db
+       # create and setup a temporary keychain, then decode the certificate and setup creditials for codesigning and notarization
+      run: |
+        security create-keychain -p "$KEYCHAINPWD" "$KEYCHAINPATH"
+
+        # Update the keychain list with our newly created temp keychain
+        security list-keychain -d user -s "$KEYCHAINPATH"
+
+        # lock the keychain after a 6 hour timeout
+        security set-keychain-settings -lut 21600 "$KEYCHAINPATH"
+
+        # prevent keychain access from prompting for password when importing our certificate
+        security unlock-keychain -p "$KEYCHAINPWD" "$KEYCHAINPATH"
+
+        echo -n "$CERT_BASE64" | base64 --decode --output $CERTPATH
+
+        # import our certificate into the temp keychain
+        security import "$CERTPATH" -P "$CERT_PWD" -t cert -f pkcs12 -k "$KEYCHAINPATH" -T /usr/bin/codesign
+
+        # allow codesign to access keychain without password prompt
+        security set-key-partition-list -S apple-tool:,apple:, -s -k "$KEYCHAINPATH" -D "$CERT_BASE64" -t private "$KEYCHAINPATH"
 
     - name: Configure
       shell: bash

--- a/.github/workflows/cmake_ctest.yml
+++ b/.github/workflows/cmake_ctest.yml
@@ -171,6 +171,17 @@ jobs:
         xcrun notarytool submit ${{ env.PRODUCT_NAME }}.dmg --apple-id ${{ secrets.NOTARIZATION_USERNAME }} --password ${{ secrets.NOTARIZATION_PASSWORD }} --team-id ${{ secrets.TEAM_ID }} --wait
         xcrun stapler staple ${{ env.PRODUCT_NAME }}.dmg
 
+    - name: Cleanup Keychain
+      if: ${{ matrix.name == 'macOS' }}
+      shell: bash
+      env:
+        KEYCHAINPATH: ${{ runner.temp }}/app-signing.keychain-db
+      run: |
+        security delete-keychain "$KEYCHAINPATH"
+
+        # default to user login keychain
+        security list-keychains -d user -s login.keychain
+
     #- name: Zip
     #  if: ${{ matrix.name == 'Linux' }}
     #  working-directory: ${{ env.ARTIFACTS_PATH }}


### PR DESCRIPTION
The action we are currently relying on, `apple-actions/import-codesign-certs`
(or, to be specific, our fork of that repo), is in a not great state. 
There are deprecations that have not been fixed, and the tip of master doesn't build (the tagged release does work, however). 

On top of that, I don't feel entirely comfortable handing off secrets to a third party action. Too 
paranoid? Perhaps. 

The changes here also show that the third party solution is a bit over engineered.
Importing certificates is a somewhat straightforward process, so why not do it right
in out action?

Also implemented is post signing cleanup of the temporary key chain used to hold our
signing certificate.