### PR TITLE
Fix: Windows installer doesn't install the plugin

### DIFF
--- a/packaging/installer.iss
+++ b/packaging/installer.iss
@@ -10,6 +10,7 @@ AppVersion={#Version}
 DefaultDirName="{commoncf64}\VST3\{#MyAppPublisher}\Valentine.vst3\"
 DisableStartupPrompt=yes
 OutputBaseFilename=valentine-{#Version}-windows
+LicenseFile="../LICENSE"
 UninstallDisplayIcon={uninstallexe}
 UninstallFilesDir={commonappdata}\{#MyAppName}\uninstall
 

--- a/packaging/installer.iss
+++ b/packaging/installer.iss
@@ -1,7 +1,6 @@
 #define Version Trim(FileRead(FileOpen("..\VERSION")))
 #define MyAppName "Valentine"
 #define MyAppPublisher "Tote Bag Labs"
-#define Year GetDateTimeString("yyyy","","")
 
 [Setup]
 AppName={#MyAppName}

--- a/packaging/installer.iss
+++ b/packaging/installer.iss
@@ -8,6 +8,7 @@ AppName={#MyAppName}
 AppPublisher={#MyAppPublisher}
 AppVersion={#Version}
 DefaultDirName="{commoncf64}\VST3\{#MyAppPublisher}\Valentine.vst3\"
+DisableDirPage=yes
 OutputBaseFilename=valentine-{#Version}-windows
 LicenseFile="../LICENSE"
 UninstallDisplayIcon={uninstallexe}

--- a/packaging/installer.iss
+++ b/packaging/installer.iss
@@ -1,6 +1,7 @@
-#define Version Trim(FileRead(FileOpen("..\VERSION")))
+#define AppUrl "https://github.com/Tote-Bag-Labs/valentine"
 #define MyAppName "Valentine"
 #define MyAppPublisher "Tote Bag Labs"
+#define Version Trim(FileRead(FileOpen("..\VERSION")))
 
 [Setup]
 AppName={#MyAppName}
@@ -8,8 +9,8 @@ AppPublisher={#MyAppPublisher}
 AppVersion={#Version}
 DefaultDirName="{commoncf64}\VST3\{#MyAppPublisher}\Valentine.vst3\"
 DisableDirPage=yes
-OutputBaseFilename=valentine-{#Version}-windows
 LicenseFile="../LICENSE"
+OutputBaseFilename=valentine-{#Version}-windows
 UninstallDisplayIcon={uninstallexe}
 UninstallFilesDir={commonappdata}\{#MyAppName}\uninstall
 

--- a/packaging/installer.iss
+++ b/packaging/installer.iss
@@ -7,8 +7,9 @@ OutputBaseFilename=Valentine-{#Version}-Windows
 AppCopyright=Copyright (C) {#Year} Tote Bag Labs
 AppPublisher=Tote Bag Labs
 AppVersion={#Version}
-DefaultDirName="{commoncf64}\VST3"
+DefaultDirName="{commoncf64}\VST3\Valentine.vst3"
 DisableStartupPrompt=yes
 
+; MSVC adds a .ilk when building the plugin. Let's not include that.
 [Files]
-Source: "{src}..\Builds\Pamplejuce_artefacts\Release\VST3\Valentine.vst3\*.*"; DestDir: "{commoncf64}\VST3\Valentine.vst3\"; Check: Is64BitInstallMode; Flags: external overwritereadonly ignoreversion; Attribs: hidden system;
+Source: "..\Builds\Valentine_artefacts\Release\VST3\Valentine.vst3\*"; DestDir: "{commoncf64}\VST3\Valentine.vst3\"; Flags: ignoreversion recursesubdirs;

--- a/packaging/installer.iss
+++ b/packaging/installer.iss
@@ -1,15 +1,16 @@
 #define Version Trim(FileRead(FileOpen("..\VERSION")))
+#define MyAppName "Valentine"
+#define MyAppPublisher "Tote Bag Labs"
 #define Year GetDateTimeString("yyyy","","")
 
 [Setup]
-AppName=Valentine
-OutputBaseFilename=Valentine-{#Version}-Windows
-AppCopyright=Copyright (C) {#Year} Tote Bag Labs
-AppPublisher=Tote Bag Labs
+AppName={#MyAppName}
+AppPublisher={#MyAppPublisher}
 AppVersion={#Version}
-DefaultDirName="{commoncf64}\VST3\Valentine.vst3"
+DefaultDirName="{commoncf64}\VST3\{#MyAppPublisher}\Valentine.vst3\"
 DisableStartupPrompt=yes
+OutputBaseFilename=valentine-{#Version}-windows
 
 ; MSVC adds a .ilk when building the plugin. Let's not include that.
 [Files]
-Source: "..\Builds\Valentine_artefacts\Release\VST3\Valentine.vst3\*"; DestDir: "{commoncf64}\VST3\Valentine.vst3\"; Flags: ignoreversion recursesubdirs;
+Source: "..\Builds\Valentine_artefacts\Release\VST3\Valentine.vst3\*"; DestDir: "{commoncf64}\VST3\{#MyAppPublisher}\Valentine.vst3\"; Excludes: *.ilk; Flags: ignoreversion recursesubdirs;

--- a/packaging/installer.iss
+++ b/packaging/installer.iss
@@ -10,7 +10,15 @@ AppVersion={#Version}
 DefaultDirName="{commoncf64}\VST3\{#MyAppPublisher}\Valentine.vst3\"
 DisableStartupPrompt=yes
 OutputBaseFilename=valentine-{#Version}-windows
+UninstallDisplayIcon={uninstallexe}
+UninstallFilesDir={commonappdata}\{#MyAppName}\uninstall
 
 ; MSVC adds a .ilk when building the plugin. Let's not include that.
 [Files]
 Source: "..\Builds\Valentine_artefacts\Release\VST3\Valentine.vst3\*"; DestDir: "{commoncf64}\VST3\{#MyAppPublisher}\Valentine.vst3\"; Excludes: *.ilk; Flags: ignoreversion recursesubdirs;
+
+[Run]
+Filename: "{cmd}"; \
+    WorkingDir: "{commoncf64}\VST3"; \
+    Parameters: "/C mklink /D /J  ""{commoncf64}\VST3\{#MyAppPublisher}\{#MyAppName}Data"" ""{commonappdata}\{#MyAppName}"""; \
+    Flags: runascurrentuser;

--- a/packaging/installer.iss
+++ b/packaging/installer.iss
@@ -8,7 +8,6 @@ AppName={#MyAppName}
 AppPublisher={#MyAppPublisher}
 AppVersion={#Version}
 DefaultDirName="{commoncf64}\VST3\{#MyAppPublisher}\Valentine.vst3\"
-DisableStartupPrompt=yes
 OutputBaseFilename=valentine-{#Version}-windows
 LicenseFile="../LICENSE"
 UninstallDisplayIcon={uninstallexe}


### PR DESCRIPTION
This PR addresses issue https://github.com/Tote-Bag-Labs/valentine/issues/11, 
which describes the Windows installer's failure to install Valentine when run.

There were many reasons for this, all coming down to pathing to the source
directory. At first, I had forgotten to change the name from the template project.
This did not fix the issue. This is probably because `recursesubdirs` was not 
specified. But it could also be because of `{src}` being used in the source
directory path.

Other improvements were added, taking liberally from Surge XT's [installer.](https://github.com/surge-synthesizer/surge/blob/main/scripts/installer_win/surge64.iss)
These include installing Valentine to a "Tote Bag Labs" folder along with a 
link to a data folder that can be used for things like factory presets or a manual.

Currently, it's just used for the uninstaller.

Some formatting things were tweaked as well. 

