### PR TITLE
Fix nice mode

### DIFF
--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -448,7 +448,7 @@ void ValentineAudioProcessor::parameterChanged (const juce::String& parameter, f
     }
     else if (parameter == "Ratio")
     {
-        ratioIndex = static_cast<int> (newValue);
+        ratioIndex = static_cast<size_t> (newValue);
         ffCompressor->setRatio (ratioValues[ratioIndex]);
         ffCompressor->setKnee (kneeValues[ratioIndex]);
 

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -451,7 +451,15 @@ void ValentineAudioProcessor::parameterChanged (const juce::String& parameter, f
         ratioIndex = static_cast<int> (newValue);
         ffCompressor->setRatio (ratioValues[ratioIndex]);
         ffCompressor->setKnee (kneeValues[ratioIndex]);
-        ffCompressor->setThreshold (thresholdValues[ratioIndex]);
+
+        if (niceModeOn.get())
+        {
+            ffCompressor->setThreshold (thresholdValues[ratioIndex] + kNiceOffset);
+        }
+        else
+        {
+            ffCompressor->setThreshold (thresholdValues[ratioIndex]);
+        }
     }
     else if (parameter == "Compress")
     {
@@ -468,9 +476,15 @@ void ValentineAudioProcessor::parameterChanged (const juce::String& parameter, f
     else if (parameter == "Nice")
     {
         if (newValue > 0.5)
-            ffCompressor->setThreshold (thresholdValues[ratioIndex] + 9.f);
+        {
+            niceModeOn.set (true);
+            ffCompressor->setThreshold (thresholdValues[ratioIndex] + kNiceOffset);
+        }
         else
+        {
+            niceModeOn.set (false);
             ffCompressor->setThreshold (thresholdValues[ratioIndex]);
+        }
     }
     else if (parameter == "Bypass")
     {

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -452,7 +452,7 @@ void ValentineAudioProcessor::parameterChanged (const juce::String& parameter, f
         ffCompressor->setRatio (ratioValues[ratioIndex]);
         ffCompressor->setKnee (kneeValues[ratioIndex]);
 
-        if (niceModeOn.get())
+        if (niceModeOn)
         {
             ffCompressor->setThreshold (thresholdValues[ratioIndex] + kNiceOffset);
         }
@@ -477,12 +477,12 @@ void ValentineAudioProcessor::parameterChanged (const juce::String& parameter, f
     {
         if (newValue > 0.5)
         {
-            niceModeOn.set (true);
+            niceModeOn = true;
             ffCompressor->setThreshold (thresholdValues[ratioIndex] + kNiceOffset);
         }
         else
         {
-            niceModeOn.set (false);
+            niceModeOn = false;
             ffCompressor->setThreshold (thresholdValues[ratioIndex]);
         }
     }

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -124,9 +124,6 @@ private:
 
     const double dryWetRampLength { .10 }; // in seconds, used in .reset()
 
-    // used to index into ratio array
-    int ratioIndex = 0;
-
     // used to maintain state for ApplyGainRamp
     // compress and makeup are addressed in dB, interface-wise, but handled linearly here
     float smoothedGain { 1.0f },
@@ -134,6 +131,8 @@ private:
         currentMakeup { juce::Decibels::decibelsToGain (FFCompParameterDefaults[getParameterIndex (VParameter::makeupGain)]) },
         currentNiceGain { 1.0f };
 
+    // Used to index into ratio array
+    size_t ratioIndex = 0;
     // Raises compressor threshold setting when Nice mode is on
     static constexpr float kNiceOffset = 9.0f;
     // Determines whether offset is used when setting compressor threshold

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -134,6 +134,8 @@ private:
         currentMakeup { juce::Decibels::decibelsToGain (FFCompParameterDefaults[getParameterIndex (VParameter::makeupGain)]) },
         currentNiceGain { 1.0f };
 
+    static constexpr float kNiceOffset = 9.0f;
+
     // compress and makeup are addressed in dB, interface-wise, but handled linearly here
     juce::Atomic<float> compressValue { juce::Decibels::decibelsToGain (FFCompParameterDefaults[getParameterIndex (VParameter::inputGain)]) },
         mixValue { 1.0f },

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -134,7 +134,10 @@ private:
         currentMakeup { juce::Decibels::decibelsToGain (FFCompParameterDefaults[getParameterIndex (VParameter::makeupGain)]) },
         currentNiceGain { 1.0f };
 
+    // Raises compressor threshold setting when Nice mode is on
     static constexpr float kNiceOffset = 9.0f;
+    // Determines whether offset is used when setting compressor threshold
+    bool niceModeOn = false;
 
     // compress and makeup are addressed in dB, interface-wise, but handled linearly here
     juce::Atomic<float> compressValue { juce::Decibels::decibelsToGain (FFCompParameterDefaults[getParameterIndex (VParameter::inputGain)]) },
@@ -148,7 +151,6 @@ private:
     juce::Atomic<int> savedWidth { 0 };
 
     juce::Atomic<bool> crushOn { false };
-    juce::Atomic<bool> niceModeOn { false };
     juce::Atomic<bool> bypassOn { false };
 
     // This is used for, yes you guessed it, processing


### PR DESCRIPTION
Valentine's compressor threshold is linked to the ratio setting.
Generally, raising the ratio raises the threshold. Valentine's threshold
setting is also affected by `nice` mode. Setting `nice` to `on` applies
an offset to the threshold, effectively raising it for all ratios.

Or at least it should. Inspection of the parameter change handling
revealed that changing the compression ratio after `nice` has been
set to on caused the threshold to be set without the offset, effectively
disabling `nice` mode despite the parameter being enabled.

This was fixed by keeping track of whether `nice` is enabled and 
using that to apply the offset whenever ratio, and hence threshold,
change.

Some other fixes were applied—the variable used to keep track of nice
mode enablement was originally used in the `processBlock`, and because
of this was `juce::Atomic<bool>`. That is no longer necessary, so it was changed to 
`bool`.

The type for the value used to access ratio values was also changed to silence
warnings about implicit type conversions.