### PR TITLE
Cleanup some missed setup in windows installer

### DIFF
--- a/scripts/installer_win/installer.iss
+++ b/scripts/installer_win/installer.iss
@@ -7,11 +7,12 @@
 AppName={#MyAppName}
 AppPublisher={#MyAppPublisher}
 AppVersion={#Version}
+ArchitecturesInstallIn64BitMode=x64
+ArchitecturesAllowed=x64
 DefaultDirName="{commoncf64}\VST3\{#MyAppPublisher}\Valentine.vst3\"
 DisableDirPage=yes
 LicenseFile="..\..\LICENSE"
 OutputBaseFilename=valentine-{#Version}-windows
-UninstallDisplayIcon={uninstallexe}
 UninstallFilesDir={commonappdata}\{#MyAppName}\uninstall
 
 ; MSVC adds a .ilk when building the plugin. Let's not include that.


### PR DESCRIPTION
Deleted a setup option that wasn't doing anything
Added a check for 64-bit architecture. This should
cause the installer to fail if user tries to install it on a non
64bit system.