### PR TITLE
Windows installer cleanups

### DIFF
--- a/scripts/installer_win/installer.iss
+++ b/scripts/installer_win/installer.iss
@@ -1,26 +1,28 @@
-#define AppUrl "https://github.com/Tote-Bag-Labs/valentine"
-#define MyAppName "Valentine"
-#define MyAppPublisher "Tote Bag Labs"
+#define PluginName "Valentine"
+#define Publisher "Tote Bag Labs"
 #define Version Trim(FileRead(FileOpen("..\..\VERSION")))
 
 [Setup]
-AppName={#MyAppName}
-AppPublisher={#MyAppPublisher}
+AppName={#PluginName}
+AppPublisher={#Publisher}
 AppVersion={#Version}
 ArchitecturesInstallIn64BitMode=x64
 ArchitecturesAllowed=x64
-DefaultDirName="{commoncf64}\VST3\{#MyAppPublisher}\Valentine.vst3\"
+DefaultDirName="{commoncf64}\VST3\{#PluginName}.vst3\"
 DisableDirPage=yes
 LicenseFile="..\..\LICENSE"
 OutputBaseFilename=valentine-{#Version}-windows
-UninstallFilesDir={commonappdata}\{#MyAppName}\uninstall
+UninstallFilesDir={commonappdata}\{#PluginName}\uninstall
+
+[UninstallDelete]
+Type: filesandordirs; Name: "{commoncf64}\VST3\{#PluginName}Data"
 
 ; MSVC adds a .ilk when building the plugin. Let's not include that.
 [Files]
-Source: "..\..\Builds\Valentine_artefacts\Release\VST3\Valentine.vst3\*"; DestDir: "{commoncf64}\VST3\{#MyAppPublisher}\Valentine.vst3\"; Excludes: *.ilk; Flags: ignoreversion recursesubdirs;
+Source: "..\..\Builds\Valentine_artefacts\Release\VST3\{#PluginName}.vst3\*"; DestDir: "{commoncf64}\VST3\{#PluginName}.vst3\"; Excludes: *.ilk; Flags: ignoreversion recursesubdirs;
 
 [Run]
 Filename: "{cmd}"; \
     WorkingDir: "{commoncf64}\VST3"; \
-    Parameters: "/C mklink /D /J  ""{commoncf64}\VST3\{#MyAppPublisher}\{#MyAppName}Data"" ""{commonappdata}\{#MyAppName}"""; \
+    Parameters: "/C mklink /D ""{commoncf64}\VST3\{#PluginName}Data"" ""{commonappdata}\{#PluginName}"""; \
     Flags: runascurrentuser;


### PR DESCRIPTION
After fixing the Windows installer, I submitted a pull
request to `pamplejuce`. In doing so, I found some things
I thought could be better. These changes are the result.

The biggest change is new directory structure for the data
directory. This was done in order to stop uninstall from
causing an error due to file explorer being in a now deleted
directory. 

Moving the symlink outside of the main install directory and
deleting it on uninstall results in error-free operation.

Should probably keep an eye on this, as I must admit that
I don't totally understand why this fix works. I'm confident, though
that a miss here will not cause harm.

Release Notes
--------------
Current users should be advised to delete their installations 
manually before installing the next release that contains these
changes. Not doing this automatically as we are still < v1.0.0.
