### PR TITLE
Cleanup (most of the) warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,8 @@ set(SourceFiles
 
     libs/tote_bag/juce_gui/Utilities/GraphicsUtilities.h
     libs/tote_bag/juce_gui/Utilities/GraphicsUtilities.cpp
+
+    libs/tote_bag/utils/macros.hpp
     )
 
 target_sources("${PROJECT_NAME}" PRIVATE ${SourceFiles})

--- a/libs/tote_bag/dsp/AudioHelpers.h
+++ b/libs/tote_bag/dsp/AudioHelpers.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 
 namespace tote_bag
@@ -99,6 +100,11 @@ inline FloatType ClampedCosh (FloatType x)
     static constexpr FloatType coshMax = 710.0;
 
     return std::cosh (std::clamp (x, coshMin, coshMax));
+}
+
+inline int nextPow2 (int x)
+{
+    return static_cast<int> ((std::pow (2, std::ceil (std::log (x) / std::log (2)))));
 }
 
 } // namespace audio_helpers

--- a/libs/tote_bag/dsp/AudioHelpers.h
+++ b/libs/tote_bag/dsp/AudioHelpers.h
@@ -102,6 +102,8 @@ inline FloatType ClampedCosh (FloatType x)
     return std::cosh (std::clamp (x, coshMin, coshMax));
 }
 
+/** Returns the the next power of 2 greater than `x`. Returns `x` if it is a power of 2
+ */
 inline int nextPow2 (int x)
 {
     return static_cast<int> ((std::pow (2, std::ceil (std::log (x) / std::log (2)))));

--- a/libs/tote_bag/dsp/CircularBuffer.h
+++ b/libs/tote_bag/dsp/CircularBuffer.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "tote_bag/dsp/AudioHelpers.h"
 #include <juce_audio_basics/juce_audio_basics.h>
 
 template <typename T>
@@ -24,14 +25,9 @@ public:
         buffer.clear();
     }
 
-    int findNextPow2 (int bufferLength)
-    {
-        return static_cast<int> ((std::pow (2, std::ceil (std::log (bufferLength) / std::log (2)))));
-    }
-
     void setSize (int inBufferLength)
     {
-        bufferLength = findNextPow2 (inBufferLength);
+        bufferLength = tote_bag::audio_helpers::nextPow2 (inBufferLength);
         wrapMask = bufferLength - 1;
         buffer.setSize (1, bufferLength, false, false, true);
         reset();

--- a/libs/tote_bag/dsp/Compressor.cpp
+++ b/libs/tote_bag/dsp/Compressor.cpp
@@ -9,7 +9,7 @@
 */
 #include "Compressor.h"
 
-Compressor::Compressor (bool autoRelease, float knee)
+Compressor::Compressor (bool autoRelease)
     : levelDetector (autoRelease)
 {
 }

--- a/libs/tote_bag/dsp/Compressor.cpp
+++ b/libs/tote_bag/dsp/Compressor.cpp
@@ -131,7 +131,7 @@ void Compressor::process (juce::dsp::AudioBlock<float>& inAudio)
     for (size_t sample = 0; sample < numSamples; sample++)
     {
         auto controlVoltage = juce::Decibels::gainToDecibels (abs (sidechain[sample]));
-        // TODO: level detector methods should be float, or templated
+        // TODO: level detector methods should be float or templated
         controlVoltage = static_cast<float> (levelDetector.processSampleDecoupledBranched (controlVoltage));
 
         controlVoltage = calculateGain (controlVoltage);

--- a/libs/tote_bag/dsp/Compressor.cpp
+++ b/libs/tote_bag/dsp/Compressor.cpp
@@ -10,7 +10,7 @@
 #include "Compressor.h"
 
 Compressor::Compressor (bool autoRelease, float knee)
-    : autoReleaseFlag (autoRelease)
+    : levelDetector (autoRelease)
 {
 }
 

--- a/libs/tote_bag/dsp/Compressor.h
+++ b/libs/tote_bag/dsp/Compressor.h
@@ -17,8 +17,6 @@
 class Compressor
 {
 public:
-    Compressor (bool autoRelease, float knee);
-
     Compressor (bool autoRelease);
 
     void reset (int numSamplesPerBlock);

--- a/libs/tote_bag/dsp/Compressor.h
+++ b/libs/tote_bag/dsp/Compressor.h
@@ -59,8 +59,7 @@ private:
         msRelease { -1.0f },
         threshold { -1.0 };
 
-    bool autoReleaseFlag { false };
-    EnvelopeDetector levelDetector { autoReleaseFlag };
+    EnvelopeDetector levelDetector;
     juce::AudioBuffer<float> analysisSignal;
 
     int overSampleMultiplier { 1 };

--- a/libs/tote_bag/dsp/DigiDegraders.cpp
+++ b/libs/tote_bag/dsp/DigiDegraders.cpp
@@ -28,7 +28,7 @@ void SimpleZOH::setResampleOffset (double inHostSr)
     }
 }
 
-void SimpleZOH::setParams (float inDownsampleCoeff, bool sampleRateChanged)
+void SimpleZOH::setParams (float inDownsampleCoeff)
 {
     downsampleCoeff = inDownsampleCoeff;
 }

--- a/libs/tote_bag/dsp/DigiDegraders.cpp
+++ b/libs/tote_bag/dsp/DigiDegraders.cpp
@@ -91,7 +91,7 @@ void Bitcrusher::processBlock (juce::AudioBuffer<float>& inAudio, int samplesPer
 
 inline float Bitcrusher::getBitcrushedSample (float inputSample, int bits)
 {
-    auto q = 1.0f / (pow (2.0f, bits) - 1);
+    const auto q = 1.0f / (std::powf (2.0f, bits) - 1);
 
-    return q * (floor (inputSample / q));
+    return q * (std::floorf (inputSample / q));
 }

--- a/libs/tote_bag/dsp/DigiDegraders.h
+++ b/libs/tote_bag/dsp/DigiDegraders.h
@@ -24,7 +24,7 @@ public:
     SimpleZOH() {};
 
     void setResampleOffset (double inHostSr);
-    void setParams (float inDownsampleCoeff, bool sampleRateChanged);
+    void setParams (float inDownsampleCoeff);
     void processBlock (juce::AudioBuffer<float>& inAudio, int samplesPerBlock, int numChannels);
     float getZOHSample (const float* channelData, int sampleIndex, int dsCoef);
 

--- a/libs/tote_bag/dsp/DigiDegraders.h
+++ b/libs/tote_bag/dsp/DigiDegraders.h
@@ -21,7 +21,7 @@
 class SimpleZOH
 {
 public:
-    SimpleZOH() {};
+    SimpleZOH() {}
 
     void setResampleOffset (double inHostSr);
     void setParams (float inDownsampleCoeff);
@@ -43,7 +43,7 @@ private:
 class Bitcrusher
 {
 public:
-    Bitcrusher() {};
+    Bitcrusher() {}
 
     void setParams (float inBitDepth);
     void processBlock (juce::AudioBuffer<float>& inAudio, int samplesPerBlock, int numChannels);
@@ -52,5 +52,5 @@ public:
 private:
     juce::Atomic<float> bitDepth { 16.0f };
 
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (Bitcrusher);
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (Bitcrusher)
 };

--- a/libs/tote_bag/dsp/Saturation.cpp
+++ b/libs/tote_bag/dsp/Saturation.cpp
@@ -49,7 +49,7 @@ inline double Saturation::inverseHyperbolicSine (double x, double gain)
     return log (xScaled + sqrt (xScaled * xScaled + 1.0)) / gain;
 }
 
-inline float Saturation::inverseHyperbolicSineInterp (float x, float gain, int channel)
+inline float Saturation::inverseHyperbolicSineInterp (float x, int channel)
 {
     auto stateSample = xState.getSample (channel, 0);
     auto diff = x - stateSample;
@@ -83,13 +83,13 @@ inline float Saturation::sineArcTangent (float x, float gain)
     return (xScaled / sqrt (1.f + xScaled * xScaled)) / gain;
 }
 
-inline double Saturation::hyperbolicTangent (double x, double gain, int channel)
+inline double Saturation::hyperbolicTangent (double x, double gain)
 {
     double xScaled = x * gain;
     return std::tanh (xScaled) / gain;
 }
 
-inline double Saturation::interpolatedHyperbolicTangent (double x, double gain, int channel)
+inline double Saturation::interpolatedHyperbolicTangent (double x, int channel)
 
 {
     auto stateSample = xState.getSample (channel, 0);
@@ -100,7 +100,7 @@ inline double Saturation::interpolatedHyperbolicTangent (double x, double gain, 
     if (abs (diff) < 0.001)
     {
         auto input = (x + stateSample) / 2.f;
-        output = hyperbolicTangent (input, 1.0f, channel);
+        output = hyperbolicTangent (input, 1.0f);
     }
     else
     {
@@ -138,13 +138,13 @@ inline double Saturation::processSample (double inputSample, int channel, double
             return sineArcTangent (inputSample, gain);
 
         case Type::hyperbolicTangent:
-            return hyperbolicTangent (inputSample, gain, channel);
+            return hyperbolicTangent (inputSample, gain);
 
         case Type::inverseHyperbolicSineInterp:
-            return inverseHyperbolicSineInterp (inputSample * gain, gain, channel) / gain;
+            return inverseHyperbolicSineInterp (inputSample * gain, channel) / gain;
 
         case Type::interpolatedHyperbolicTangent:
-            return interpolatedHyperbolicTangent (inputSample * gain, gain, channel) / gain;
+            return interpolatedHyperbolicTangent (inputSample * gain, channel) / gain;
 
         default:
             //somehow the distortion type was not set. It must be set!

--- a/libs/tote_bag/dsp/Saturation.h
+++ b/libs/tote_bag/dsp/Saturation.h
@@ -51,13 +51,13 @@ public:
 
     inline double inverseHyperbolicSine (double x, double gain);
 
-    inline float inverseHyperbolicSineInterp (float x, float gain, int channel);
+    inline float inverseHyperbolicSineInterp (float x, int channel);
 
     inline float sineArcTangent (float x, float gain);
 
-    inline double hyperbolicTangent (double x, double gain, int channel);
+    inline double hyperbolicTangent (double x, double gain);
 
-    inline double interpolatedHyperbolicTangent (double x, double gain, int channel);
+    inline double interpolatedHyperbolicTangent (double x, int channel);
 
     inline double hyperTanFirstAntiDeriv (double x);
 

--- a/libs/tote_bag/juce_gui/components/panels/PresetPanel.cpp
+++ b/libs/tote_bag/juce_gui/components/panels/PresetPanel.cpp
@@ -94,10 +94,10 @@ void PresetPanel::decrementPreset()
 
 void PresetPanel::savePreset()
 {
-    auto currentPresetName = presetManager.getCurrentPresetName();
+    const auto presetName = presetManager.getCurrentPresetName();
 
     juce::String currentPresetPath = presetManager.getCurrentPresetDirectory()
-                                     + static_cast<std::string> (directorySeparator) + currentPresetName;
+                                     + static_cast<std::string> (directorySeparator) + presetName;
 
     juce::FileChooser chooser ("Save a file: ",
                                juce::File (currentPresetPath),

--- a/libs/tote_bag/juce_gui/components/panels/PresetPanel.h
+++ b/libs/tote_bag/juce_gui/components/panels/PresetPanel.h
@@ -23,7 +23,7 @@ public:
                  const juce::String& bypassButtonText,
                  const juce::String& bypassParameterId,
                  juce::AudioProcessorValueTreeState& treeState);
-    ~PresetPanel();
+    ~PresetPanel() override;
 
     void paint (juce::Graphics& g) override;
 

--- a/libs/tote_bag/juce_gui/components/panels/VerticalMeterPanel.cpp
+++ b/libs/tote_bag/juce_gui/components/panels/VerticalMeterPanel.cpp
@@ -15,11 +15,10 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 
 //==============================================================================
-VerticalMeterPanel::VerticalMeterPanel (const juce::String& label,
-                                        ReductionMeterPlacement grMeterPlacement,
+VerticalMeterPanel::VerticalMeterPanel (ReductionMeterPlacement reductionMeterPlacement,
                                         foleys::LevelMeterSource* levelMeterSource,
                                         foleys::LevelMeterSource* grMeterSource)
-    : grMeterPlacement (grMeterPlacement)
+    : grMeterPlacement (reductionMeterPlacement)
 {
     using namespace tote_bag::laf_constants;
 

--- a/libs/tote_bag/juce_gui/components/panels/VerticalMeterPanel.h
+++ b/libs/tote_bag/juce_gui/components/panels/VerticalMeterPanel.h
@@ -27,8 +27,7 @@ class ValentineAudioProcessor;
 class VerticalMeterPanel : public juce::Component
 {
 public:
-    VerticalMeterPanel (const juce::String& label,
-                        ReductionMeterPlacement grMeterPlacement,
+    VerticalMeterPanel (ReductionMeterPlacement reductionMeterPlacement,
                         foleys::LevelMeterSource* levelMeterSource,
                         foleys::LevelMeterSource* grMeterSource = nullptr);
 

--- a/libs/tote_bag/juce_gui/components/widgets/FlatTextChooser.cpp
+++ b/libs/tote_bag/juce_gui/components/widgets/FlatTextChooser.cpp
@@ -69,10 +69,6 @@ FlatTextChooser::~FlatTextChooser()
 {
 }
 
-void FlatTextChooser::paint (juce::Graphics& g)
-{
-}
-
 void FlatTextChooser::resized()
 {
     const auto mainArea = getLocalBounds();

--- a/libs/tote_bag/juce_gui/components/widgets/FlatTextChooser.cpp
+++ b/libs/tote_bag/juce_gui/components/widgets/FlatTextChooser.cpp
@@ -85,7 +85,7 @@ void FlatTextChooser::resized()
 
     if (mAlignWithParameterSliders)
     {
-        buttonArea.removeFromBottom (buttonArea.getHeight() * .15f);
+        buttonArea.removeFromBottom (static_cast<int>(buttonArea.getHeight() * .15f));
     }
 
     // The buttons themselves shouldn't take up all of the horizontal space

--- a/libs/tote_bag/juce_gui/components/widgets/FlatTextChooser.h
+++ b/libs/tote_bag/juce_gui/components/widgets/FlatTextChooser.h
@@ -36,7 +36,6 @@ public:
                      bool);
     ~FlatTextChooser() override;
 
-    void paint (juce::Graphics&) override;
     void resized() override;
 
 private:

--- a/libs/tote_bag/juce_gui/components/widgets/LabelSlider.cpp
+++ b/libs/tote_bag/juce_gui/components/widgets/LabelSlider.cpp
@@ -30,10 +30,6 @@ LabelSlider::~LabelSlider()
 {
 }
 
-void LabelSlider::paint (juce::Graphics& g)
-{
-}
-
 void LabelSlider::resized()
 {
     const auto mainArea = getLocalBounds();

--- a/libs/tote_bag/juce_gui/components/widgets/LabelSlider.h
+++ b/libs/tote_bag/juce_gui/components/widgets/LabelSlider.h
@@ -30,7 +30,6 @@ public:
 
     ~LabelSlider() override;
 
-    void paint (juce::Graphics&) override;
     void resized() override;
 
 private:

--- a/libs/tote_bag/juce_gui/lookandfeel/LookAndFeel.cpp
+++ b/libs/tote_bag/juce_gui/lookandfeel/LookAndFeel.cpp
@@ -139,7 +139,7 @@ void LookAndFeel::drawKnob (juce::Graphics& g,
     g.fillEllipse (rx, ry, rw, rw);
 
     // Get thicknesses for outline rings...
-    const auto innerOutlineThickness = juce::jmax ((rw * .05f), 1.0f);
+    const auto innerOutlineThickness = juce::roundToInt (juce::jmax ((rw * .05f), 1.0f));
     const auto outerOutlineThickness = innerOutlineThickness * .15f;
 
     // Offset inner outline by its thickness
@@ -239,7 +239,7 @@ void LookAndFeel::drawButtonBackground (juce::Graphics& g,
     auto buttonArea = button.getLocalBounds();
     const auto h = buttonArea.getHeight();
 
-    const auto cornerSize = h * .15;
+    const auto cornerSize = juce::roundToInt (h * .15);
 
     g.setColour (backgroundColour);
 
@@ -377,8 +377,8 @@ juce::Slider::SliderLayout LookAndFeel::getSliderLayout (juce::Slider& slider)
     auto localBounds = slider.getLocalBounds();
 
     auto sDiameter = juce::jmin (localBounds.getWidth(), localBounds.getHeight()) - 4.0f;
-    auto textBoxWidth = sDiameter * .66f;
-    auto textBoxHeight = sDiameter * .17f;
+    auto textBoxWidth = juce::roundToInt (sDiameter * .66f);
+    auto textBoxHeight = juce::roundToInt (sDiameter * .17f);
 
     juce::Slider::SliderLayout layout;
 

--- a/libs/tote_bag/juce_gui/lookandfeel/LookAndFeel.cpp
+++ b/libs/tote_bag/juce_gui/lookandfeel/LookAndFeel.cpp
@@ -123,7 +123,7 @@ void LookAndFeel::drawKnob (juce::Graphics& g,
                             const float radius,
                             const float toAngle,
                             const juce::Rectangle<float> bounds,
-                            juce::Slider& slider,
+                            juce::Slider&,
                             const bool withDropShadow)
 {
     const auto centreX = bounds.getCentreX();
@@ -215,12 +215,12 @@ void LookAndFeel::drawRotarySlider (juce::Graphics& g,
 
 //=============================================================================
 
-juce::Typeface::Ptr LookAndFeel::getTypefaceForFont (const juce::Font& f)
+juce::Typeface::Ptr LookAndFeel::getTypefaceForFont (const juce::Font&)
 {
     return getCustomFont().getTypefacePtr();
 }
 
-juce::Font LookAndFeel::getTextButtonFont (juce::TextButton& b, int buttonHeight)
+juce::Font LookAndFeel::getTextButtonFont (juce::TextButton&, int buttonHeight)
 {
     return { juce::jmax (7.0f, buttonHeight * 0.8f) };
 }
@@ -234,7 +234,7 @@ void LookAndFeel::drawButtonBackground (juce::Graphics& g,
                                         juce::Button& button,
                                         const juce::Colour& backgroundColour,
                                         bool,
-                                        bool isButtonDown)
+                                        bool)
 {
     auto buttonArea = button.getLocalBounds();
     const auto h = buttonArea.getHeight();
@@ -316,7 +316,7 @@ void LookAndFeel::drawButtonText (juce::Graphics& g,
 }
 
 void LookAndFeel::drawComboBox (juce::Graphics& g,
-                                int width,
+                                int,
                                 int height,
                                 bool,
                                 int,
@@ -339,15 +339,15 @@ void LookAndFeel::drawComboBox (juce::Graphics& g,
 
 void LookAndFeel::drawPopupMenuItem (juce::Graphics& g,
                                      const juce::Rectangle<int>& area,
-                                     bool isSeparator,
-                                     bool isActive,
+                                     bool,
+                                     bool,
                                      bool isHighlighted,
                                      bool isTicked,
-                                     bool hasSubMenu,
+                                     bool,
                                      const juce::String& text,
-                                     const juce::String& shortcutKeyText,
-                                     const juce::Drawable* icon,
-                                     const juce::Colour* textColour)
+                                     const juce::String&,
+                                     const juce::Drawable*,
+                                     const juce::Colour*)
 {
     using namespace laf_constants;
 
@@ -372,15 +372,7 @@ juce::Slider::SliderLayout LookAndFeel::getSliderLayout (juce::Slider& slider)
 {
     // 1. compute the actually visible textBox size from the slider textBox size and some additional constraints
 
-    int minXSpace = 0;
-    int minYSpace = 0;
-
     auto textBoxPos = slider.getTextBoxPosition();
-
-    if (textBoxPos == juce::Slider::TextBoxLeft || textBoxPos == juce::Slider::TextBoxRight)
-        minXSpace = 30;
-    else
-        minYSpace = 15;
 
     auto localBounds = slider.getLocalBounds();
 

--- a/libs/tote_bag/juce_gui/lookandfeel/LookAndFeel.h
+++ b/libs/tote_bag/juce_gui/lookandfeel/LookAndFeel.h
@@ -50,7 +50,7 @@ public:
                    const float radius,
                    const float toAngle,
                    const juce::Rectangle<float> bounds,
-                   juce::Slider& slider,
+                   juce::Slider&,
                    const bool withDropShadow);
 
     void drawRotarySlider (juce::Graphics& g,
@@ -63,7 +63,7 @@ public:
                            const float rotaryEndAngle,
                            juce::Slider&) override;
 
-    juce::Typeface::Ptr getTypefaceForFont (const juce::Font& f) override;
+    juce::Typeface::Ptr getTypefaceForFont (const juce::Font&) override;
 
     juce::Font getTextButtonFont (juce::TextButton&, int buttonHeight) override;
 
@@ -73,7 +73,7 @@ public:
                                juce::Button& button,
                                const juce::Colour& backgroundColour,
                                bool,
-                               bool isButtonDown) override;
+                               bool) override;
 
     void drawFlatButtonBackground (juce::Graphics& g,
                                    tote_bag::FlatTextButton& button,
@@ -87,7 +87,7 @@ public:
                          bool isButtonDown) override;
 
     void drawComboBox (juce::Graphics& g,
-                       int width,
+                       int,
                        int height,
                        bool,
                        int,
@@ -98,15 +98,15 @@ public:
 
     void drawPopupMenuItem (juce::Graphics& g,
                             const juce::Rectangle<int>& area,
-                            bool isSeparator,
-                            bool isActive,
+                            bool,
+                            bool,
                             bool isHighlighted,
                             bool isTicked,
-                            bool hasSubMenu,
+                            bool,
                             const juce::String& text,
-                            const juce::String& shortcutKeyText,
-                            const juce::Drawable* icon,
-                            const juce::Colour* textColour) override;
+                            const juce::String&,
+                            const juce::Drawable*,
+                            const juce::Colour*) override;
 
     juce::Slider::SliderLayout getSliderLayout (juce::Slider& slider) override;
 

--- a/libs/tote_bag/juce_gui/lookandfeel/MeterLookAndFeelMethods.h
+++ b/libs/tote_bag/juce_gui/lookandfeel/MeterLookAndFeelMethods.h
@@ -131,16 +131,16 @@ juce::Rectangle<float> getMeterBarBounds (const juce::Rectangle<float> bounds,
 
 /** Override this callback to define the placement of the tickmarks.
  To disable this feature return an empty rectangle. */
-juce::Rectangle<float> getMeterTickmarksBounds (const juce::Rectangle<float> bounds,
-                                                const FFAU::LevelMeter::MeterFlags meterType) const override
+juce::Rectangle<float> getMeterTickmarksBounds (const juce::Rectangle<float>,
+                                                const FFAU::LevelMeter::MeterFlags) const override
 {
     return juce::Rectangle<float>();
 }
 
 /** Override this callback to define the placement of the clip indicator light.
  To disable this feature return an empty rectangle. */
-juce::Rectangle<float> getMeterClipIndicatorBounds (const juce::Rectangle<float> bounds,
-                                                    const FFAU::LevelMeter::MeterFlags meterType) const override
+juce::Rectangle<float> getMeterClipIndicatorBounds (const juce::Rectangle<float>,
+                                                    const FFAU::LevelMeter::MeterFlags) const override
 {
     return juce::Rectangle<float>();
 }
@@ -207,8 +207,8 @@ void drawMeterBars (juce::Graphics& g,
                     const FFAU::LevelMeter::MeterFlags meterType,
                     const juce::Rectangle<float> bounds,
                     const FFAU::LevelMeterSource* source,
-                    const int fixedNumChannels = -1,
-                    const int selectedChannel = -1) override
+                    const int,
+                    const int) override
 {
     const juce::Rectangle<float> innerBounds = getMeterInnerBounds (bounds, meterType);
     if (source)
@@ -382,11 +382,11 @@ void drawMeterBarsBackground (juce::Graphics& g,
     }
 }
 
-void drawMeterChannel (juce::Graphics& g,
-                       const FFAU::LevelMeter::MeterFlags meterType,
-                       const juce::Rectangle<float> bounds,
-                       const FFAU::LevelMeterSource* source,
-                       const int selectedChannel) override
+void drawMeterChannel (juce::Graphics&,
+                       const FFAU::LevelMeter::MeterFlags,
+                       const juce::Rectangle<float>,
+                       const FFAU::LevelMeterSource*,
+                       const int) override
 {
 }
 
@@ -650,9 +650,9 @@ void drawMaxNumber (juce::Graphics& g,
                       1);
 }
 
-void drawMaxNumberBackground (juce::Graphics& g,
-                              [[maybe_unused]] const FFAU::LevelMeter::MeterFlags meterType,
-                              const juce::Rectangle<float> bounds) override
+void drawMaxNumberBackground (juce::Graphics&,
+                              const FFAU::LevelMeter::MeterFlags,
+                              const juce::Rectangle<float>) override
 {
 }
 

--- a/libs/tote_bag/juce_gui/lookandfeel/MeterLookAndFeelMethods.h
+++ b/libs/tote_bag/juce_gui/lookandfeel/MeterLookAndFeelMethods.h
@@ -95,7 +95,7 @@ juce::Rectangle<float> getMeterBarBounds (const juce::Rectangle<float> bounds,
         {
             const float margin = bounds.getHeight() * 0.001f;
             const float top = bounds.getY() + 2.0f * margin;
-            const float bottom = (meterType & FFAU::LevelMeter::MaxNumber) ? bounds.getBottom() - (3.0f * margin + ((bounds.getHeight() * .1) - margin * 2.0f))
+            const float bottom = (meterType & FFAU::LevelMeter::MaxNumber) ? bounds.getBottom() - (3.0f * margin + ((bounds.getHeight() * .1f) - margin * 2.0f))
                                                                            : bounds.getBottom() - margin;
             return juce::Rectangle<float> (bounds.getX() + margin, top, bounds.getWidth() - margin * 2.0f, bottom - top);
         }

--- a/libs/tote_bag/juce_gui/managers/RadioButtonGroupManager.cpp
+++ b/libs/tote_bag/juce_gui/managers/RadioButtonGroupManager.cpp
@@ -19,7 +19,7 @@ RadioButtonGroupManager::RadioButtonGroupManager (juce::AudioParameterChoice& pa
     : mParameter (parameter)
     , mGroupId (groupId)
 {
-    mCurrentParameterIndex = mParameter.getIndex();
+    mCurrentParameterIndex = static_cast<size_t> (mParameter.getIndex());
 
     startTimerHz (20);
 }
@@ -57,7 +57,7 @@ void RadioButtonGroupManager::attach (juce::Button* button)
     ++mNextButtonIndex;
 }
 
-void RadioButtonGroupManager::buttonOnClickCallback (juce::Button* button, int index)
+void RadioButtonGroupManager::buttonOnClickCallback (juce::Button* button, size_t index)
 {
     auto buttonOn = button->getToggleState();
 
@@ -75,7 +75,7 @@ void RadioButtonGroupManager::buttonOnClickCallback (juce::Button* button, int i
 
 void RadioButtonGroupManager::updateGroupState()
 {
-    const auto parameterIndex = mParameter.getIndex();
+    const auto parameterIndex = static_cast<size_t> (mParameter.getIndex());
     if (mCurrentParameterIndex != parameterIndex)
     {
         mManagedButtons[parameterIndex]->setToggleState (true,

--- a/libs/tote_bag/juce_gui/managers/RadioButtonGroupManager.h
+++ b/libs/tote_bag/juce_gui/managers/RadioButtonGroupManager.h
@@ -27,7 +27,7 @@ class RadioButtonGroupManager : public juce::Timer
 public:
     RadioButtonGroupManager (juce::AudioParameterChoice& parameter, int groupId);
 
-    ~RadioButtonGroupManager();
+    ~RadioButtonGroupManager() override;
 
     void timerCallback() override;
 

--- a/libs/tote_bag/juce_gui/managers/RadioButtonGroupManager.h
+++ b/libs/tote_bag/juce_gui/managers/RadioButtonGroupManager.h
@@ -41,7 +41,7 @@ private:
     /** Called by a managed button's onClick() method to change button and
         parameter state.
      */
-    void buttonOnClickCallback (juce::Button* button, int index);
+    void buttonOnClickCallback (juce::Button* button, size_t index);
 
     /** Called periodically to check if param value has changed in a way not driven
         by a click on the button itself. e.g. via automation.
@@ -51,8 +51,8 @@ private:
     juce::AudioParameterChoice& mParameter;
     std::vector<juce::Button*> mManagedButtons;
     int mGroupId { 0 };
-    int mCurrentParameterIndex { 0 };
-    int mNextButtonIndex { 0 };
+    size_t mCurrentParameterIndex { 0 };
+    size_t mNextButtonIndex { 0 };
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (RadioButtonGroupManager)
 };

--- a/libs/tote_bag/juce_gui/managers/ToteBagPresetManager.cpp
+++ b/libs/tote_bag/juce_gui/managers/ToteBagPresetManager.cpp
@@ -58,7 +58,7 @@ void ToteBagPresetManager::savePreset (juce::File presetFile)
     processor->getStateInformation (destinationData);
 
     // write the preset data to file
-    presetFile.appendData (destinationData.getData(), static_cast<int> (destinationData.getSize()));
+    presetFile.appendData (destinationData.getData(), destinationData.getSize());
 
     updatePresetList();
 }

--- a/libs/tote_bag/juce_gui/utilities/GraphicsUtilities.cpp
+++ b/libs/tote_bag/juce_gui/utilities/GraphicsUtilities.cpp
@@ -22,7 +22,7 @@ void drawRoundedRect (juce::Graphics& g,
 
     auto h = croppedBounds.getHeight();
     auto lineThickness = h * .025f;
-    auto cornerSize = h * .25;
+    auto cornerSize = h * .25f;
 
     g.setColour (colour.darker());
 

--- a/libs/tote_bag/utils/macros.hpp
+++ b/libs/tote_bag/utils/macros.hpp
@@ -1,0 +1,16 @@
+//
+//  macros.hpp
+//  Assets
+//
+//  Created by Jose Diaz on 25.03.23.
+//
+
+#ifndef macros_hpp
+#define macros_hpp
+
+/** Silences "unused parameter" compiler warnings. Ideally, of course, one would remove the unused
+    parameter. However, it is sometimes more expedient to (temporarily) use this macro.
+ */
+#define TBL_Unused(x) (void) (x)
+
+#endif /* macros_hpp */

--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -18,21 +18,17 @@ ValentineAudioProcessorEditor::ValentineAudioProcessorEditor (ValentineAudioProc
 {
     addAndMakeVisible (mainPanel);
 
-    auto w = 0.0f;
-
-    if (auto savedWidth = processor.getSavedGUIwidth())
-        w = savedWidth;
-    else
-        w = startingWidth;
+    const auto savedWidth = audioProcessor.getSavedGUIwidth();
+    const auto w = savedWidth != 0 ? savedWidth : startingWidth;
 
     setResizable (true, true);
     setResizeLimits (minimumWidth,
-                     minimumWidth / ratio,
+                     juce::roundToInt (minimumWidth / ratio),
                      maximumWidth,
-                     maximumWidth / ratio);
+                     juce::roundToInt (maximumWidth / ratio));
     getConstrainer()->setFixedAspectRatio (ratio);
 
-    setSize (w, w / ratio);
+    setSize (w, juce::roundToInt (w / ratio));
 }
 
 ValentineAudioProcessorEditor::~ValentineAudioProcessorEditor()

--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -14,7 +14,8 @@
 //==============================================================================
 ValentineAudioProcessorEditor::ValentineAudioProcessorEditor (ValentineAudioProcessor& p)
     : AudioProcessorEditor (&p)
-    , processor (p)
+    , audioProcessor (p)
+    , mainPanel (audioProcessor)
 {
     addAndMakeVisible (mainPanel);
 
@@ -33,7 +34,7 @@ ValentineAudioProcessorEditor::ValentineAudioProcessorEditor (ValentineAudioProc
 
 ValentineAudioProcessorEditor::~ValentineAudioProcessorEditor()
 {
-    processor.saveGUIwidth (getWidth());
+    audioProcessor.saveGUIwidth (getWidth());
 }
 
 //==============================================================================

--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -38,9 +38,6 @@ ValentineAudioProcessorEditor::~ValentineAudioProcessorEditor()
 }
 
 //==============================================================================
-void ValentineAudioProcessorEditor::paint (juce::Graphics& g)
-{
-}
 
 void ValentineAudioProcessorEditor::resized()
 {

--- a/src/PluginEditor.h
+++ b/src/PluginEditor.h
@@ -32,9 +32,9 @@ public:
 private:
     // This reference is provided as a quick way for your editor to
     // access the processor object that created it.
-    ValentineAudioProcessor& processor;
+    ValentineAudioProcessor& audioProcessor;
 
-    VMainPanel mainPanel { processor };
+    VMainPanel mainPanel;
 
     // in figma ~ 5053 x 1741. ratio = 2.9 ish width to height
     static constexpr float ratio = 2.5f;

--- a/src/PluginEditor.h
+++ b/src/PluginEditor.h
@@ -26,7 +26,6 @@ public:
     ~ValentineAudioProcessorEditor();
 
     //==============================================================================
-    void paint (juce::Graphics&) override;
     void resized() override;
 
 private:

--- a/src/PluginEditor.h
+++ b/src/PluginEditor.h
@@ -23,7 +23,7 @@ class ValentineAudioProcessorEditor : public juce::AudioProcessorEditor
 {
 public:
     ValentineAudioProcessorEditor (ValentineAudioProcessor&);
-    ~ValentineAudioProcessorEditor();
+    ~ValentineAudioProcessorEditor() override;
 
     //==============================================================================
     void resized() override;

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -183,16 +183,16 @@ int ValentineAudioProcessor::getCurrentProgram()
     return 0;
 }
 
-void ValentineAudioProcessor::setCurrentProgram (int index)
+void ValentineAudioProcessor::setCurrentProgram (int)
 {
 }
 
-const juce::String ValentineAudioProcessor::getProgramName (int index)
+const juce::String ValentineAudioProcessor::getProgramName (int)
 {
     return {};
 }
 
-void ValentineAudioProcessor::changeProgramName (int index, const juce::String& newName)
+void ValentineAudioProcessor::changeProgramName (int, const juce::String&)
 {
 }
 
@@ -280,7 +280,7 @@ bool ValentineAudioProcessor::isBusesLayoutSupported (const BusesLayout& layouts
 }
 #endif
 
-void ValentineAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages)
+void ValentineAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce::MidiBuffer&)
 {
     juce::ScopedNoDenormals noDenormals;
     auto totalNumInputChannels = getTotalNumInputChannels();

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -544,7 +544,7 @@ void ValentineAudioProcessor::setStateInformation (const void* data, int sizeInB
 
 void ValentineAudioProcessor::initializeDSP()
 {
-    ffCompressor = std::make_unique<Compressor> (false, 3.84f);
+    ffCompressor = std::make_unique<Compressor> (false);
 
     saturator = std::make_unique<Saturation> (Saturation::Type::inverseHyperbolicSineInterp, .6f);
 

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -215,7 +215,7 @@ void ValentineAudioProcessor::prepareToPlay (double sampleRate, int samplesPerBl
 
     saturator->reset (sampleRate);
     boundedSaturator->reset (sampleRate);
-    simpleZOH->setParams (sampleRate / downSampleRate, false);
+    simpleZOH->setParams (sampleRate / downSampleRate);
 
     // Calculate delay, round up. That's the delay reported to host. subtract
     // the original delay from that and you have the fractional delay

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -353,14 +353,14 @@ void ValentineAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, ju
     dryWet.setTargetValue (mix);
     for (int j = 0; j < currentSamplesPerBlock; ++j)
     {
-        auto mix = dryWet.getNextValue();
+        const auto currentMix = dryWet.getNextValue();
 
         for (int i = 0; i < totalNumOutputChannels; ++i)
         {
             auto processed = processBuffer.getSample (i, j);
             auto unprocessed = buffer.getSample (i, j);
 
-            buffer.setSample (i, j, mix * processed + (1.0f - mix) * unprocessed);
+            buffer.setSample (i, j, mix * processed + (1.0f - currentMix) * unprocessed);
         }
     }
 

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -59,9 +59,9 @@ public:
     //==============================================================================
     int getNumPrograms() override;
     int getCurrentProgram() override;
-    void setCurrentProgram (int index) override;
-    const juce::String getProgramName (int index) override;
-    void changeProgramName (int index, const juce::String& newName) override;
+    void setCurrentProgram (int) override;
+    const juce::String getProgramName (int) override;
+    void changeProgramName (int, const juce::String&) override;
 
     //==============================================================================
     void parameterChanged (const juce::String& parameter, float newValue) override;

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -31,7 +31,7 @@ class ValentineAudioProcessor : public juce::AudioProcessor,
 public:
     //==============================================================================
     ValentineAudioProcessor();
-    ~ValentineAudioProcessor();
+    ~ValentineAudioProcessor() override;
 
     //==============================================================================
     void prepareToPlay (double sampleRate, int samplesPerBlock) override;

--- a/src/gui/panels/ValentineCenterPanel.cpp
+++ b/src/gui/panels/ValentineCenterPanel.cpp
@@ -91,8 +91,9 @@ void CenterPanel::resized()
 {
     auto workingArea = getLocalBounds();
 
-    auto areaFunc = [] (juce::Rectangle<int>& area, int numSliders, int sliderCount) -> juce::Rectangle<int> {
-        return area.removeFromLeft (area.getWidth() / (numSliders - sliderCount));
+    auto areaFunc = [] (juce::Rectangle<int>& area, size_t numSliders, size_t sliderCount) -> juce::Rectangle<int> {
+        int amountToRemove = juce::roundToInt (static_cast<float> (area.getWidth()) / static_cast<float> (numSliders - sliderCount));
+        return area.removeFromLeft (amountToRemove);
     };
 
     const auto paramWidth = juce::roundToInt (workingArea.getWidth() / 5.0f);
@@ -106,7 +107,7 @@ void CenterPanel::resized()
     workingArea.removeFromTop (verticalAlignmentSpacer);
     workingArea.removeFromBottom (verticalAlignmentSpacer);
 
-    const auto borderMargin = paramWidth * .05f;
+    const auto borderMargin = static_cast<int> (paramWidth * .05f);
 
     // Left side
     const auto numLeftColumns = 3;
@@ -123,22 +124,23 @@ void CenterPanel::resized()
         &saturateSlider
     };
 
-    for (int i = 0; i < numLeftColumns; ++i)
+    for (size_t i = 0; i < numLeftColumns; ++i)
     {
         topLeftRowComponents[i]->setBounds (areaFunc (topLeftRowBounds, numLeftColumns, i));
     }
 
+    const auto roundedRowMargin = juce::roundToInt (betweenRowMargin);
     // Margin
-    leftSideBounds.removeFromTop (betweenRowMargin);
+    leftSideBounds.removeFromTop (roundedRowMargin);
 
     // Bottom
     auto bottomRowParamHeight = juce::roundToInt (paramWidth * .65f);
-    const auto smallborderMargin = bottomRowParamHeight * .05f;
+    const auto smallborderMargin = juce::roundToInt (bottomRowParamHeight * .05f);
     bottomLeftRowBorderBounds = leftSideBounds.removeFromTop (bottomRowParamHeight);
 
     auto bottomLeftRowBounds = bottomLeftRowBorderBounds.reduced (smallborderMargin);
 
-    auto ratioBounds = bottomLeftRowBounds.removeFromLeft (bottomLeftRowBounds.getWidth() / 3.0f);
+    auto ratioBounds = bottomLeftRowBounds.removeFromLeft (juce::roundToInt (bottomLeftRowBounds.getWidth() / 3.0f));
     mRatioBox->setBounds (ratioBounds);
 
     const auto numBottomLeftColumns = numLeftColumns - 1;
@@ -148,13 +150,13 @@ void CenterPanel::resized()
         &releaseSlider
     };
 
-    for (int i = 0; i < numBottomLeftColumns; ++i)
+    for (size_t i = 0; i < numBottomLeftColumns; ++i)
     {
         bottomLeftRowComponents[i]->setBounds (areaFunc (bottomLeftRowBounds, numBottomLeftColumns, i));
     }
 
     // Vertical margin
-    workingArea.removeFromLeft (betweenRowMargin);
+    workingArea.removeFromLeft (roundedRowMargin);
 
     const auto numRightColumns = 2;
     auto rightSideBounds = workingArea.removeFromLeft (paramWidth * numRightColumns);
@@ -169,13 +171,13 @@ void CenterPanel::resized()
         &mixSlider
     };
 
-    for (int i = 0; i < numRightColumns; ++i)
+    for (size_t i = 0; i < numRightColumns; ++i)
     {
         topRightRowComponents[i]->setBounds (areaFunc (topRightRowBounds, numRightColumns, i));
     }
 
     // Margin
-    rightSideBounds.removeFromTop (betweenRowMargin);
+    rightSideBounds.removeFromTop (roundedRowMargin);
 
     // Bottom right
     auto logoHeight = juce::roundToInt (paramWidth * .5f);

--- a/src/gui/panels/ValentineMainPanel.cpp
+++ b/src/gui/panels/ValentineMainPanel.cpp
@@ -19,11 +19,9 @@ VMainPanel::VMainPanel (ValentineAudioProcessor& processor)
                    FFCompParameterLabel()[getParameterIndex (VParameter::bypass)],
                    FFCompParameterID()[getParameterIndex (VParameter::bypass)],
                    processor.treeState)
-    , inputMeterPanel ("In",
-                       ReductionMeterPlacement::Right,
+    , inputMeterPanel (ReductionMeterPlacement::Right,
                        &processor.getInputMeterSource())
-    , outputMeterPanel ("Out",
-                        ReductionMeterPlacement::Left,
+    , outputMeterPanel (ReductionMeterPlacement::Left,
                         &processor.getOutputMeterSource(),
                         &processor.getGrMeterSource())
     , centerPanel (processor)

--- a/src/gui/panels/ValentineMainPanel.h
+++ b/src/gui/panels/ValentineMainPanel.h
@@ -24,7 +24,7 @@ class VMainPanel : public juce::Component
 {
 public:
     VMainPanel (ValentineAudioProcessor& inProcessor);
-    ~VMainPanel();
+    ~VMainPanel() override;
 
     void paint (juce::Graphics& g) override;
 

--- a/tests/AudioHelpersTests.cpp
+++ b/tests/AudioHelpersTests.cpp
@@ -1,0 +1,21 @@
+//
+//  AudioHelpersTests.cpp
+//  Valentine
+//
+//  Created by Jose Diaz on 19.03.23.
+//
+
+#include "tote_bag/dsp/AudioHelpers.h"
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+TEST_CASE ("Next power of two", "[Audio Helpers]")
+{
+    // Finds the next power of two for given input
+    const int nextPower = tote_bag::audio_helpers::nextPow2 (200);
+    REQUIRE (nextPower == 256);
+
+    // Returns the same as input if it is a power of 2
+    const int nextPowerSame = tote_bag::audio_helpers::nextPow2 (256);
+    REQUIRE (nextPowerSame == 256);
+}

--- a/tests/AudioHelpersTests.hpp
+++ b/tests/AudioHelpersTests.hpp
@@ -1,0 +1,13 @@
+//
+//  AudioHelpersTests.hpp
+//  Valentine
+//
+//  Created by Jose Diaz on 19.03.23.
+//
+
+#ifndef AudioHelpersTests_hpp
+#define AudioHelpersTests_hpp
+
+#include <stdio.h>
+
+#endif /* AudioHelpersTests_hpp */


### PR DESCRIPTION
The pamplejuce temple uses JUCE's recommended warnings.
As such, building Valentine from it exposed all kinds of things that 
I had missed.

These changes address most of these warnings, mostly by avoiding
implicit casts, removing unused variables from interfaces, and removing
unused member functions and variables from classes.

Some warnings remain: they are in dsp classes where I think special
scrutiny must be applied in order to avoid unintentional changes to 
Valentine's sound or performance.