### PR TITLE
Add build and .cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ _deps
 # It's nice to have the Builds folder exist, to remind us where it is
 Builds/*
 !Builds/.gitkeep
+Build/*
+!Build/.gitkeep
 
 # This should never exist
 Install/*
@@ -27,3 +29,6 @@ Testing
 cmake-build-debug
 cmake-build-release
 cmake-build-relwithdebinfo
+
+# lldb cache
+.cache/


### PR DESCRIPTION
I'm working on building valentine using vscode, using lldb for debugging.
The defaults for building from cmake using vscode's cmake tools extension
creates a `Build` folder. This is a spelling choice one might generally make when
configuring, so I thought it best to add to `.gitignore`.

lldb creates a `.cache` file, which we also do not want to check in.