### PR TITLE
Spruce up thiran

### DIFF
--- a/libs/tote_bag/dsp/ThiranAllpass.h
+++ b/libs/tote_bag/dsp/ThiranAllpass.h
@@ -55,23 +55,12 @@ public:
 
     void prepare (T inDelay)
     {
-        // This class needs to be refactored. It can only operate as a first order
-        // filter, but here we accept an arbitrary delay amount. This will cause a
-        // crash if a value equal to or larger than 1 is passed in. This is because
-        // this value is truncated and used to determine the order of the filter
-        // values smaller than 1 are truncated to 0, resulting in a buffer size of 1, or
-        // a first order filter. The difference between the passed in delay value and
-        // it's truncated N is used to calculate our coefficients
-        // TODO: make sure this can actually handle all the delay values that may be given to it.
-        // TODO: conversely, refactor to only allow fractional delays of less than one sample.
-        jassert (inDelay < 1);
-
         // get the desired delay and figure out filter order.
         if (delay != inDelay)
         {
             delay = inDelay;
-            N = static_cast<int> (delay);
-            bufSize = N + 1;
+            N = 1;
+            bufSize = N;
 
             xBuf.setSize (bufSize);
             yBuf.setSize (bufSize);

--- a/libs/tote_bag/dsp/ThiranAllpass.h
+++ b/libs/tote_bag/dsp/ThiranAllpass.h
@@ -29,12 +29,12 @@ public:
     }
 
     /** Calculates the filter coefficients. This is called automatically by prepare().
+     *  see Splitting the Unit Delay: Tools for Fractional Delay Filter Design
+     *  T.I. Laakso; V. Valimaki; M. Karjalainen; U.K. Laine; et al.
      */
     void makeCoefficients()
     {
-        T product = 1.0;
-        product *= (delay - 1.0) / (delay + 1.0);
-        a1 = product;
+        a1 = (1.0f - delay) / (1.0f + delay);
     }
 
     /** Take a mono AudioBlock and processes it

--- a/libs/tote_bag/dsp/ThiranAllpass.h
+++ b/libs/tote_bag/dsp/ThiranAllpass.h
@@ -24,17 +24,8 @@ public:
         if (delay != inDelay)
         {
             delay = inDelay;
-            makeCoefficients();
+            updateCoefficients();
         }
-    }
-
-    /** Calculates the filter coefficients. This is called automatically by prepare().
-     *  see Splitting the Unit Delay: Tools for Fractional Delay Filter Design
-     *  T.I. Laakso; V. Valimaki; M. Karjalainen; U.K. Laine; et al.
-     */
-    void makeCoefficients()
-    {
-        a1 = (1.0f - delay) / (1.0f + delay);
     }
 
     /** Take a mono AudioBlock and processes it
@@ -58,6 +49,15 @@ public:
     }
 
 private:
+    /** Calculates the filter coefficients. This is called automatically by prepare().
+     * see Splitting the Unit Delay: Tools for Fractional Delay Filter Design
+     * T.I. Laakso; V. Valimaki; M. Karjalainen; U.K. Laine; et al.
+     */
+    void updateCoefficients()
+    {
+        a1 = (1.0f - delay) / (1.0f + delay);
+    }
+
     T delay = 0.0;
     T a1 = 0.0;
     T accumulator = 0.0;

--- a/libs/tote_bag/dsp/ThiranAllpass.h
+++ b/libs/tote_bag/dsp/ThiranAllpass.h
@@ -12,15 +12,24 @@
 
 #include <cassert>
 
+/** A first order Thiran allpass filter. This is a simple allpass filter that
+ *  has a single coefficient, a1, and a single state variable, accumulator.
+ *  This filter will sound best for delay times around 1 sample.
+ */
 template <typename T>
 class FirstOrderThiranAllpass
 {
 public:
+    /** Resets the filter state to zero. This should be called before processing.
+     */
     void reset()
     {
         accumulator = 0.0;
     }
 
+    /** Prepares the filter for processing. This should be called before processing.
+     *  @param inDelay The delay time in samples. This should be between 0 and 2.
+     */
     void prepare (T inDelay)
     {
         assert (inDelay > 0.0);

--- a/libs/tote_bag/dsp/ThiranAllpass.h
+++ b/libs/tote_bag/dsp/ThiranAllpass.h
@@ -10,96 +10,34 @@
 
 #pragma once
 
-#include "tote_bag/dsp/AudioHelpers.h"
-#include "tote_bag/dsp/CircularBuffer.h"
-
-#include <juce_dsp/juce_dsp.h>
-
-#include <array>
-
-struct ThiranScalars
-{
-    /*
-       precalculated for a Nth order filters,
-       will calculate exact delay in prepare()
-       [0] is always 1. Keeping here for easier indexing
-     
-       -1^k * (binomial coefficient of N k)
-     
-       N       N!
-         =  ----------
-       k    k!(N - k)!
-     
-       Should compute a lookup table to avoid calculating factorials
-       for a more flexible implementation
-    
-    */
-
-    const std::array<int, 2> firstOrder = { 1, -1 };
-    const std::array<int, 5> fourthOrder = { 1, -4, 6, -4, 1 };
-    const std::array<int, 6> sixthOrder = { 1, -5, 10, -10, 5, -1 };
-};
-
-/** An allpass filter desined for fractional delay. Currently supports delay amounts
-    < 1 sample, but theoretically could handle more (as shown by the above coefficient arrays).
- */
 template <typename T>
-class ThiranAllPass
+class FirstOrderThiranAllpass
 {
 public:
     void reset()
     {
-        xBuf.reset();
-        yBuf.reset();
+        accumulator = 0.0;
     }
 
     void prepare (T inDelay)
     {
-        // get the desired delay and figure out filter order.
         if (delay != inDelay)
         {
             delay = inDelay;
-            N = 1;
-            bufSize = N;
-
-            xBuf.setSize (bufSize);
-            yBuf.setSize (bufSize);
-
             makeCoefficients();
         }
     }
 
+    /** Calculates the filter coefficients. This is called automatically by prepare().
+     */
     void makeCoefficients()
     {
-        // from https://ccrma.stanford.edu/~jos/pasp/Thiran_Allpass_Interpolation_Matlab.html
-
-        if (aCoeffs.size() != bufSize)
-            aCoeffs.resize (bufSize);
-        if (bCoeffs.size() != bufSize)
-            bCoeffs.resize (bufSize);
-
-        //an attempt at ameliorating the level boost
-        aCoeffs[0] = 0.7943282347242815;
-
-        for (int i = 1; i < N + 1; i++)
-        {
-            auto product = 1.0;
-
-            for (int n = 0; n < N + 1; n++)
-            {
-                product = product * (delay - N + n) / (delay - N + i + n);
-
-                aCoeffs[i] = std::pow (-1, i) * scalars.firstOrder[i] * product;
-            }
-        }
-
-        int k = N;
-        for (auto coeff : aCoeffs)
-            bCoeffs[k--] = coeff;
+        T product = 1.0;
+        product *= (delay - 1.0) / (delay + 1.0);
+        a1 = product;
     }
 
     /** Take a mono AudioBlock and processes it
-        Direct Form I since the order / delay is integral to the filtering
      */
     void process (juce::dsp::AudioBlock<float>& inBlock)
     {
@@ -108,28 +46,19 @@ public:
         auto blockLen = inBlock.getNumSamples();
         auto inAudio = inBlock.getChannelPointer (0);
 
-        for (int sample = 0; sample < blockLen; ++sample)
+        for (size_t sample = 0; sample < blockLen; ++sample)
         {
-            auto v = bCoeffs[0] * inAudio[sample];
+            const T x = inAudio[sample];
 
-            for (int i = 1; i < bCoeffs.size(); ++i)
-                v += bCoeffs[i] * xBuf.readBuffer (i, false);
+            const T y = a1 * x + accumulator;
 
-            xBuf.writeBuffer (inAudio[sample]);
-
-            for (int i = 1; i < aCoeffs.size(); ++i)
-                v -= aCoeffs[i] * yBuf.readBuffer (i, false);
-
-            inAudio[sample] = v * aCoeffs[0];
-
-            yBuf.writeBuffer (inAudio[sample]);
+            inAudio[sample] = y;
+            accumulator = x - (a1 * y);
         }
     }
 
 private:
-    std::vector<T> aCoeffs, bCoeffs;
-    CircularBuffer<T> xBuf, yBuf;
-    T delay;
-    int N, bufSize;
-    ThiranScalars scalars;
+    T delay = 0.0;
+    T a1 = 0.0;
+    T accumulator = 0.0;
 };

--- a/libs/tote_bag/dsp/ThiranAllpass.h
+++ b/libs/tote_bag/dsp/ThiranAllpass.h
@@ -34,7 +34,7 @@ public:
 
     /** Take a mono AudioBlock and processes it
      */
-    void process (juce::dsp::AudioBlock<float>& inBlock)
+    void process (juce::dsp::AudioBlock<T>& inBlock)
     {
         juce::ScopedNoDenormals noDenormals;
 

--- a/libs/tote_bag/dsp/ThiranAllpass.h
+++ b/libs/tote_bag/dsp/ThiranAllpass.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include <cassert>
+
 template <typename T>
 class FirstOrderThiranAllpass
 {
@@ -21,6 +23,8 @@ public:
 
     void prepare (T inDelay)
     {
+        assert (inDelay > 0.0);
+
         if (delay != inDelay)
         {
             delay = inDelay;

--- a/libs/tote_bag/dsp/ThiranAllpass.h
+++ b/libs/tote_bag/dsp/ThiranAllpass.h
@@ -32,22 +32,18 @@ public:
         }
     }
 
-    /** Take a mono AudioBlock and processes it
+    /** Processes a buffer of samples. This should be called after prepare().
+     *  @param buffer The buffer to process.
+     *  @param numSamples The number of samples in the buffer.
      */
-    void process (juce::dsp::AudioBlock<T>& inBlock)
+    void process (T* buffer, size_t numSamples)
     {
-        juce::ScopedNoDenormals noDenormals;
-
-        auto blockLen = inBlock.getNumSamples();
-        auto inAudio = inBlock.getChannelPointer (0);
-
-        for (size_t sample = 0; sample < blockLen; ++sample)
+        for (size_t sample = 0; sample < numSamples; ++sample)
         {
-            const T x = inAudio[sample];
+            const auto x = buffer[sample];
+            const auto y = a1 * x + accumulator;
 
-            const T y = a1 * x + accumulator;
-
-            inAudio[sample] = y;
+            buffer[sample] = y;
             accumulator = x - (a1 * y);
         }
     }

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -222,8 +222,7 @@ void ValentineAudioProcessor::prepareToPlay (double sampleRate, int samplesPerBl
     // for processed data.
     // .5 for the the interpolated tanh() latency,
     // .5 for the interp inverse sine latency
-    // 1.0 for the minimum fractional filter delay.
-    const auto overSamplingDelay = oversampler->getLatencyInSamples() + 2.0f;
+    const auto overSamplingDelay = oversampler->getLatencyInSamples() + 1.0f;
     const auto reportedDelay = static_cast<int> (std::ceil (overSamplingDelay));
     const auto fracDelay = reportedDelay - overSamplingDelay;
     setLatencySamples (reportedDelay);
@@ -232,7 +231,7 @@ void ValentineAudioProcessor::prepareToPlay (double sampleRate, int samplesPerBl
     for (auto& filter : fracDelayFilters)
     {
         filter->reset();
-        filter->prepare (1.0f + fracDelay);
+        filter->prepare (fracDelay);
     }
 
     for (auto& buffer : unProcBuffers)

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -219,9 +219,11 @@ void ValentineAudioProcessor::prepareToPlay (double sampleRate, int samplesPerBl
 
     // Calculate delay, round up. That's the delay reported to host. subtract
     // the original delay from that and you have the fractional delay
-    // for processed data. .5 for the the interpolated tanh() latency,
+    // for processed data.
+    // .5 for the the interpolated tanh() latency,
     // .5 for the interp inverse sine latency
-    const auto overSamplingDelay = oversampler->getLatencyInSamples() + 1.0f;
+    // 1.0 for the minimum fractional filter delay.
+    const auto overSamplingDelay = oversampler->getLatencyInSamples() + 2.0f;
     const auto reportedDelay = static_cast<int> (std::ceil (overSamplingDelay));
     const auto fracDelay = reportedDelay - overSamplingDelay;
     setLatencySamples (reportedDelay);
@@ -230,7 +232,7 @@ void ValentineAudioProcessor::prepareToPlay (double sampleRate, int samplesPerBl
     for (auto& filter : fracDelayFilters)
     {
         filter->reset();
-        filter->prepare (fracDelay);
+        filter->prepare (1.0f + fracDelay);
     }
 
     for (auto& buffer : unProcBuffers)

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -559,7 +559,7 @@ void ValentineAudioProcessor::initializeDSP()
     bitCrush = std::make_unique<Bitcrusher>();
 
     for (auto& filter : fracDelayFilters)
-        filter.reset (new ThiranAllPass<double>);
+        filter.reset (new FirstOrderThiranAllpass<double>);
 
     for (auto& buffer : unProcBuffers)
     {

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -558,7 +558,7 @@ void ValentineAudioProcessor::initializeDSP()
     bitCrush = std::make_unique<Bitcrusher>();
 
     for (auto& filter : fracDelayFilters)
-        filter.reset (new FirstOrderThiranAllpass<double>);
+        filter.reset (new FirstOrderThiranAllpass<float>);
 
     for (auto& buffer : unProcBuffers)
     {

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -337,8 +337,10 @@ void ValentineAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, ju
     const auto numOutputChannels = static_cast<size_t> (totalNumOutputChannels);
     for (size_t channel = 0; channel < numOutputChannels; ++channel)
     {
-        juce::dsp::AudioBlock<float> channelBlock = processBlock.getSingleChannelBlock (channel);
-        fracDelayFilters[channel]->process (channelBlock);
+        auto channelPointer = processBlock.getChannelPointer (channel);
+        const auto blockLength = processBlock.getNumSamples();
+
+        fracDelayFilters[channel]->process (channelPointer, blockLength);
     }
 
     // Apply Makeup

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -157,7 +157,7 @@ private:
 
     // DSP objects
     std::array<std::unique_ptr<CircularBuffer<float>>, 2> unProcBuffers;
-    std::array<std::unique_ptr<FirstOrderThiranAllpass<double>>, 2> fracDelayFilters;
+    std::array<std::unique_ptr<FirstOrderThiranAllpass<float>>, 2> fracDelayFilters;
     std::unique_ptr<tote_bag::audio_helpers::SimpleOnePole<float>> dryWetFilter;
     std::unique_ptr<Oversampling> oversampler;
     std::unique_ptr<Compressor> ffCompressor;

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -157,7 +157,7 @@ private:
 
     // DSP objects
     std::array<std::unique_ptr<CircularBuffer<float>>, 2> unProcBuffers;
-    std::array<std::unique_ptr<ThiranAllPass<double>>, 2> fracDelayFilters;
+    std::array<std::unique_ptr<FirstOrderThiranAllpass<double>>, 2> fracDelayFilters;
     std::unique_ptr<tote_bag::audio_helpers::SimpleOnePole<float>> dryWetFilter;
     std::unique_ptr<Oversampling> oversampler;
     std::unique_ptr<Compressor> ffCompressor;


### PR DESCRIPTION
These changes improve Valentine's sound my more correctly
aligning processed and unprocessed signal in the audio processor.
They also greatly simplify the allpass interpolator used for this
alignment.

The underlying issues were found when attempting to 
resolve compiler warnings in `ThiranAllpass.h`. Upon examination,
I realized that the implementation wasn't really doing what I 
thought it was.

Instead of creating filter coefficients for a given delay amount, 
errors in my implementation lead to the same coefficients being 
set regardless of what has been set.

This is because `N`, the filter order, was being cast to `int`, 
making it `0` for values less than `1`. This leads to _problems_
when calculating the filter's coefficients, as the filter's order is 
needed.

Furthermore, I didn't take into account that the limitation imposed
by my naive implementation: delay times smaller than one sample
were not possible. This meant that, to correctly use it to increase
the processing buffer's latency to an integral number of samples, 
I had to increase the overall system delay by 1 sample, adding one
extra sample of delay to the unprocessed signal and 1 + fraction
samples of delay to the processed signal.

I also found my implementation unnecessarily complex.
A lot of this was because I thought the filter order would need
to be greater than 1 at some point. Though there may be arguments
for this, my current uses don't really require it. Restricting the filter
to first order makes it much easier to implement.

While I was in there, I also decided to remove any use of `JUCE`
classes. They add an unnecessary dependency.

And yes, the warnings are resolved.