### PR TITLE
Linux Validation Support

### DIFF
--- a/.github/workflows/cmake_ctest.yml
+++ b/.github/workflows/cmake_ctest.yml
@@ -31,13 +31,16 @@ jobs:
         include:
           - name: Linux
             os: ubuntu-22.04
-            #pluginval-binary: ./pluginval
+            pluginval-binary: ./pluginval
+            pluginval-strictness: 1
           - name: macOS
             os: macos-12
             pluginval-binary: pluginval.app/Contents/MacOS/pluginval
+            pluginval-strictness: 10
           - name: windows
             os: windows-latest
             pluginval-binary: ./pluginval.exe
+            pluginval-strictness: 10
 
     steps:
     - name: Set up Clang
@@ -134,7 +137,7 @@ jobs:
       run: |
         curl -LO "https://github.com/Tracktion/pluginval/releases/download/v1.0.1/pluginval_${{ matrix.name }}.zip"
         7z x pluginval_${{ matrix.name }}.zip
-        ${{ matrix.pluginval-binary }} --strictness-level 10 --verbose --validate "${{ env.VST3_PATH }}"
+        ${{ matrix.pluginval-binary }} --strictness-level ${{ matrix.pluginval-strictness }} --verbose --validate "${{ env.VST3_PATH }}"
 
     - name: Codesign (macOS)
       working-directory: ${{ env.BUILD_DIR }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(PROJECT_NAME "Valentine")
 
 # Set the plugin formats you'll be building here.
 # Valid formats: AAX Unity VST AU AUv3 Standalone
-set(FORMATS AU VST3)
+set(FORMATS AU VST3 Standalone)
 
 # Reads in VERSION file and sticks in it CURRENT_VERSION variable
 # Be sure the file has no newlines

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -50,8 +50,6 @@ ValentineAudioProcessor::~ValentineAudioProcessor()
     {
         treeState.removeParameterListener (param, this);
     }
-
-    testManager->deleteInstance();
 }
 
 //==============================================================================
@@ -59,7 +57,6 @@ ValentineAudioProcessor::~ValentineAudioProcessor()
 juce::AudioProcessorValueTreeState::ParameterLayout
     ValentineAudioProcessor::createParameterLayout()
 {
-    testManager = juce::MessageManager::getInstance();
     std::vector<std::unique_ptr<juce::RangedAudioParameter>> params;
 
     for (size_t i = 0; i < numParams; ++i)

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -166,7 +166,5 @@ private:
     std::unique_ptr<SimpleZOH> simpleZOH;
     std::unique_ptr<Bitcrusher> bitCrush;
 
-    juce::MessageManager* testManager;
-
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ValentineAudioProcessor)
 };


### PR DESCRIPTION
1. Don't create a message manager in the DSP thread
2. Set validation level to 1 for linux since the leak of a Glyph (run the standalone and quit to see it) holds a timer in UI tests it seems
3. Add the Standalone to the CMake