### PR TITLE
Don't create a new look and feel object for meters

### DIFF
--- a/libs/tote_bag/juce_gui/components/panels/VerticalMeterPanel.cpp
+++ b/libs/tote_bag/juce_gui/components/panels/VerticalMeterPanel.cpp
@@ -22,12 +22,6 @@ VerticalMeterPanel::VerticalMeterPanel (ReductionMeterPlacement reductionMeterPl
 {
     using namespace tote_bag::laf_constants;
 
-    metersLookAndFeel.setColour (FFAU::LevelMeter::lmBackgroundColour, vPink);
-    metersLookAndFeel.setColour (FFAU::LevelMeter::lmMeterGradientLowColour, (vGreen1));
-    metersLookAndFeel.setColour (FFAU::LevelMeter::lmMeterGradientMidColour, vGreen2);
-    metersLookAndFeel.setColour (FFAU::LevelMeter::lmMeterMaxOverColour, vRed);
-
-    levelMeter.setLookAndFeel (&metersLookAndFeel);
     levelMeter.setMeterSource (levelMeterSource);
     addAndMakeVisible (levelMeter);
 
@@ -35,13 +29,31 @@ VerticalMeterPanel::VerticalMeterPanel (ReductionMeterPlacement reductionMeterPl
     {
         gainReductionMeter = std::make_unique<FFAU::LevelMeter> (FFAU::LevelMeter::MeterFlags::Reduction);
         gainReductionMeter->setMeterSource (grMeterSource);
-        gainReductionMeter->setLookAndFeel (&metersLookAndFeel);
         addAndMakeVisible (gainReductionMeter.get());
     }
 }
 
 VerticalMeterPanel::~VerticalMeterPanel()
 {
+}
+
+void VerticalMeterPanel::lookAndFeelChanged()
+{
+    using namespace tote_bag::laf_constants;
+
+    auto& lookAndFeel = getLookAndFeel();
+
+    lookAndFeel.setColour (FFAU::LevelMeter::lmBackgroundColour, vPink);
+    lookAndFeel.setColour (FFAU::LevelMeter::lmMeterGradientLowColour, (vGreen1));
+    lookAndFeel.setColour (FFAU::LevelMeter::lmMeterGradientMidColour, vGreen2);
+    lookAndFeel.setColour (FFAU::LevelMeter::lmMeterMaxOverColour, vRed);
+
+    levelMeter.setLookAndFeel (&lookAndFeel);
+
+    if (gainReductionMeter.get())
+    {
+        gainReductionMeter->setLookAndFeel (&lookAndFeel);
+    }
 }
 
 void VerticalMeterPanel::resized()

--- a/libs/tote_bag/juce_gui/components/panels/VerticalMeterPanel.h
+++ b/libs/tote_bag/juce_gui/components/panels/VerticalMeterPanel.h
@@ -35,9 +35,9 @@ public:
 
     void resized() override;
 
-private:
-    tote_bag::LookAndFeel metersLookAndFeel;
+    void lookAndFeelChanged() override;
 
+private:
     FFAU::LevelMeter levelMeter { FFAU::LevelMeter::MeterFlags::Minimal };
 
     std::unique_ptr<FFAU::LevelMeter> gainReductionMeter;

--- a/src/gui/panels/ValentineMainPanel.cpp
+++ b/src/gui/panels/ValentineMainPanel.cpp
@@ -26,12 +26,12 @@ VMainPanel::VMainPanel (ValentineAudioProcessor& processor)
                         &processor.getGrMeterSource())
     , centerPanel (processor)
 {
-    setLookAndFeel (&lookAndFeel);
-
     addAndMakeVisible (presetPanel);
     addAndMakeVisible (centerPanel);
     addAndMakeVisible (inputMeterPanel);
     addAndMakeVisible (outputMeterPanel);
+
+    setLookAndFeel (&lookAndFeel);
 }
 
 VMainPanel::~VMainPanel()

--- a/src/gui/panels/ValentineMainPanel.h
+++ b/src/gui/panels/ValentineMainPanel.h
@@ -24,6 +24,7 @@ class VMainPanel : public juce::Component
 {
 public:
     VMainPanel (ValentineAudioProcessor& inProcessor);
+
     ~VMainPanel() override;
 
     void paint (juce::Graphics& g) override;


### PR DESCRIPTION
Just get it from the component hierarchy—it's more clear 
this way. We generally depend on parent look and feel to sort 
out that of a given component. This pattern was broken 
here because of the desire to set some extra colours in the level
meters constructor. 

Better: override `lookAndFeelChanged` and, when it is called, get the 
parent look and feel, make the changes we need, and pass it into the 
meter components that need it.