### PR TITLE
Enable upload of linux artifacts in workflow [ci skip]

### DIFF
--- a/.github/workflows/cmake_ctest.yml
+++ b/.github/workflows/cmake_ctest.yml
@@ -219,12 +219,12 @@ jobs:
         name: ${{ env.OUTPUT_FILENAME }}.exe
         path: '${{ env.ARTIFACTS_PATH }}/${{ env.OUTPUT_FILENAME }}.exe'
 
-    #- name: Upload Zip (Linux)
-    #  if: ${{ matrix.name == 'Linux' }}
-    #  uses: actions/upload-artifact@v3
-    #  with:
-    #    name: ${{ env.OUTPUT_FILENAME }}.zip
-    #    path: '${{ env.ARTIFACTS_PATH }}/${{ env.OUTPUT_FILENAME }}.zip'
+    - name: Upload Zip (Linux)
+     if: ${{ matrix.name == 'Linux' }}
+     uses: actions/upload-artifact@v3
+     with:
+       name: ${{ env.OUTPUT_FILENAME }}.zip
+       path: '${{ env.ARTIFACTS_PATH }}/${{ env.OUTPUT_FILENAME }}.zip'
 
     - name: Upload DMG (MacOS)
       if: ${{ matrix.name == 'macOS' }}


### PR DESCRIPTION
We need this to release linux, of course.