### PR TITLE
Improve custom font handling

### DIFF
--- a/.github/workflows/cmake_ctest.yml
+++ b/.github/workflows/cmake_ctest.yml
@@ -32,7 +32,7 @@ jobs:
           - name: Linux
             os: ubuntu-22.04
             pluginval-binary: ./pluginval
-            pluginval-strictness: 1
+            pluginval-strictness: 10
           - name: macOS
             os: macos-12
             pluginval-binary: pluginval.app/Contents/MacOS/pluginval
@@ -132,7 +132,6 @@ jobs:
 
     - name: Pluginval
       working-directory: ${{ env.BUILD_DIR }}
-      if: ${{ matrix.name != 'Linux' }}
       shell: bash
       run: |
         curl -LO "https://github.com/Tracktion/pluginval/releases/download/v1.0.1/pluginval_${{ matrix.name }}.zip"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,8 @@ set(SourceFiles
 
     libs/tote_bag/juce_gui/utilities/GraphicsUtilities.h
     libs/tote_bag/juce_gui/utilities/GraphicsUtilities.cpp
+    libs/tote_bag/juce_gui/utilities/tbl_font.h
+    libs/tote_bag/juce_gui/utilities/tbl_font.cpp
 
     libs/tote_bag/utils/macros.hpp
     )

--- a/libs/tote_bag/juce_gui/lookandfeel/LookAndFeel.cpp
+++ b/libs/tote_bag/juce_gui/lookandfeel/LookAndFeel.cpp
@@ -22,8 +22,6 @@ LookAndFeel::LookAndFeel()
 
     setupDefaultMeterColours();
 
-    setDefaultLookAndFeel (this);
-
     // slider colours
     setColour (ColourIds::knobColourId, juce::Colours::grey);
     setColour (ColourIds::pointerColourId, juce::Colours::black);

--- a/libs/tote_bag/juce_gui/lookandfeel/LookAndFeel.cpp
+++ b/libs/tote_bag/juce_gui/lookandfeel/LookAndFeel.cpp
@@ -13,20 +13,9 @@
 
 #include "tote_bag/juce_gui/components/widgets/FlatTextButton.h"
 
-#include "BinaryData.h"
-
-namespace
-{
-const juce::Font getCustomFont()
-{
-    static auto typeface = juce::Typeface::createSystemTypefaceFor (BinaryData::MontserratMedium_ttf,
-                                                                    BinaryData::MontserratMedium_ttfSize);
-    return juce::Font (typeface);
-}
-}
-
 namespace tote_bag
 {
+
 LookAndFeel::LookAndFeel()
 {
     using namespace tote_bag::laf_constants;
@@ -213,21 +202,16 @@ void LookAndFeel::drawRotarySlider (juce::Graphics& g,
     drawKnob (g, knobRadius, toAngle, bounds, slider, true);
 }
 
-//=============================================================================
-
-juce::Typeface::Ptr LookAndFeel::getTypefaceForFont (const juce::Font&)
-{
-    return getCustomFont().getTypefacePtr();
-}
-
 juce::Font LookAndFeel::getTextButtonFont (juce::TextButton&, int buttonHeight)
 {
-    return { juce::jmax (7.0f, buttonHeight * 0.8f) };
+    const auto fontHeight = juce::jmax (7.0f, buttonHeight * 0.8f);
+    return fontHolder.getFont("MontserratMedium_ttf").withHeight (fontHeight);
 }
 
 juce::Font LookAndFeel::getLabelFont (juce::Label& l)
 {
-    return { static_cast<float> (l.getHeight()) };
+    const auto fontHeight = static_cast<float> (l.getHeight());
+    return fontHolder.getFont("MontserratMedium_ttf").withHeight (fontHeight);
 }
 
 void LookAndFeel::drawButtonBackground (juce::Graphics& g,
@@ -328,7 +312,7 @@ void LookAndFeel::drawComboBox (juce::Graphics& g,
     const auto boxBounds = box.getLocalBounds();
 
     const auto fontHeight = juce::jmax (7.0f, height * 0.6f);
-    g.setFont (juce::Font (fontHeight));
+    g.setFont (fontHolder.getFont("MontserratMedium_ttf").withHeight (fontHeight));
 
     g.setColour (box.findColour (juce::ComboBox::backgroundColourId));
 
@@ -361,7 +345,7 @@ void LookAndFeel::drawPopupMenuItem (juce::Graphics& g,
     g.setColour (myTextColour);
 
     auto fHeight = juce::jmax (7.0f, r.getHeight() * 0.6f);
-    g.setFont (juce::Font (fHeight));
+    g.setFont (fontHolder.getFont("MontserratMedium_ttf").withHeight (fHeight));
 
     r.setLeft (10);
     r.setY (1);

--- a/libs/tote_bag/juce_gui/lookandfeel/LookAndFeel.h
+++ b/libs/tote_bag/juce_gui/lookandfeel/LookAndFeel.h
@@ -10,11 +10,13 @@
 
 #pragma once
 
+#include "tote_bag/juce_gui/utilities/tbl_font.h"
+
 #include <ff_meters/ff_meters.h>
-#include <juce_gui_basics/juce_gui_basics.h>
 
 namespace tote_bag
 {
+
 class FlatTextButton;
 
 class LookAndFeel : public juce::LookAndFeel_V4,
@@ -62,8 +64,6 @@ public:
                            const float rotaryStartAngle,
                            const float rotaryEndAngle,
                            juce::Slider&) override;
-
-    juce::Typeface::Ptr getTypefaceForFont (const juce::Font&) override;
 
     juce::Font getTextButtonFont (juce::TextButton&, int buttonHeight) override;
 
@@ -114,6 +114,9 @@ public:
         knobColourId = 0x1001800,
         pointerColourId = 0x1001801
     };
+
+private:
+    FontHolder fontHolder;
 
 #include "MeterLookAndFeelMethods.h"
 };

--- a/libs/tote_bag/juce_gui/utilities/tbl_font.cpp
+++ b/libs/tote_bag/juce_gui/utilities/tbl_font.cpp
@@ -1,0 +1,39 @@
+// Tote Bag Labs 2023
+
+#include "tbl_font.h"
+
+namespace tote_bag
+{
+
+juce::Font FontHolder::getFont(const juce::String& fontName)
+{
+    auto fontIt = fonts.find(fontName);
+    if (fontIt == fonts.end())
+    {
+        int size = 0;
+        const auto resource = BinaryData::getNamedResource (fontName.toRawUTF8(), size);
+
+        // Make sure you've passed the correct font name to this function.
+        // If you're sure you've done that, make sure you've added the font
+        // to your assets dir and BinaryData files.
+        jassert(resource != nullptr);
+
+        auto typeface = (juce::Typeface::createSystemTypefaceFor (resource,
+                                                                  static_cast<size_t>(size)));
+
+        auto font = std::make_unique<juce::Font> (typeface);
+
+        const auto[newFontIt, inserted] = fonts.insert({fontName, std::move(font)});
+        if(!inserted)
+        {
+            jassertfalse;
+            return juce::Font{};
+        }
+
+        fontIt = newFontIt;
+    }
+
+    return *fontIt->second;
+}
+
+} // namespace tote_bag

--- a/libs/tote_bag/juce_gui/utilities/tbl_font.h
+++ b/libs/tote_bag/juce_gui/utilities/tbl_font.h
@@ -1,0 +1,27 @@
+// Tote Bag Labs 2023
+
+#include "BinaryData.h"
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#include <map>
+
+#pragma once
+
+namespace tote_bag
+{
+
+/** A class that holds our custom fonts.
+ */
+class FontHolder
+{
+    public:
+    /** Gets a Font from the map, creating it if it doesn't exist.
+     */
+    juce::Font getFont(const juce::String& fontName);
+
+    private:
+    std::map<juce::String, std::unique_ptr<juce::Font>> fonts;
+};
+
+} // namespace tote_bag


### PR DESCRIPTION
Finally building and running in linux revealed an issue—memory leaks associated
with the custom font. This is likely because the font was being created with 
`static` lifetime duration.

The implementation had other issues—we were getting our custom font by
setting a new default typeface, which required setting our look and feel as 
the default on instantiation. This makes it hard to reason about the lifetime
of our look and feel, especially when several instances of the plugin are open
at once.

Not only that, the standing implementation restricted us to the use of one font
for all of our components. What if we want a different font or different styling?

To resolve these issues, a font holding class was introduced. It can create and
store an arbitrary number of custom fonts in a resource efficient manner (which 
was the point of using `static` in the first place). Furthermore, it is destroyed when
its owning look and feel is destroyed. So it should not leak.

Implementing fonts this way require the new holder to be called whenever a font is
needed, instead of relying on the singleton-like semantics of using a default font.
This makes the code easier to understand and allows for the use of different fonts
if desired.