### PR TITLE
Spruce up crush

### DIFF
--- a/libs/tote_bag/dsp/DigiDegraders.cpp
+++ b/libs/tote_bag/dsp/DigiDegraders.cpp
@@ -11,6 +11,8 @@
 #include "DigiDegraders.h"
 #include "tote_bag/dsp/AudioHelpers.h"
 
+#include <cassert>
+
 void SimpleZOH::setResampleOffset (double inHostSr)
 {
     /*
@@ -65,6 +67,9 @@ inline float SimpleZOH::getZOHSample (const float* channelData, int sampleIndex,
 
 void Bitcrusher::setParams (float inBitDepth)
 {
+    // An bit depth of 0 will cause a divide by zero error
+    assert(inBitDepth > 0);
+
     bitDepth.set (inBitDepth);
 }
 
@@ -86,7 +91,7 @@ void Bitcrusher::processBlock (juce::AudioBuffer<float>& inAudio, int samplesPer
 
 inline float Bitcrusher::getBitcrushedSample (float inputSample, float bits)
 {
-    const auto q = 1.0f / (powf (2.0f, bits) - 1);
+    const auto q = 1.0f / powf (2.0f, bits);
 
     return q * (floorf (inputSample / q));
 }

--- a/libs/tote_bag/dsp/DigiDegraders.cpp
+++ b/libs/tote_bag/dsp/DigiDegraders.cpp
@@ -84,12 +84,12 @@ void Bitcrusher::processBlock (juce::AudioBuffer<float>& inAudio, int samplesPer
         for (int sample = 0; sample < samplesPerBlock; ++sample)
         {
             const float inputSample = channelData[sample];
-            channelData[sample] = getBitcrushedSample(inputSample, bits);
+            channelData[sample] = asymmetricBitcrush(inputSample, bits);
         }
     }
 }
 
-inline float Bitcrusher::getBitcrushedSample (float inputSample, float bits)
+inline float Bitcrusher::asymmetricBitcrush (float inputSample, float bits)
 {
     const auto q = 1.0f / powf (2.0f, bits);
 

--- a/libs/tote_bag/dsp/DigiDegraders.cpp
+++ b/libs/tote_bag/dsp/DigiDegraders.cpp
@@ -93,5 +93,5 @@ inline float Bitcrusher::getBitcrushedSample (float inputSample, float bits)
 {
     const auto q = 1.0f / powf (2.0f, bits);
 
-    return q * (floorf (inputSample / q));
+    return q * floorf ((inputSample / q));
 }

--- a/libs/tote_bag/dsp/DigiDegraders.cpp
+++ b/libs/tote_bag/dsp/DigiDegraders.cpp
@@ -70,9 +70,7 @@ void Bitcrusher::setParams (float inBitDepth)
 
 void Bitcrusher::processBlock (juce::AudioBuffer<float>& inAudio, int samplesPerBlock, int numChannels)
 {
-    auto bD = bitDepth.get();
-    auto intBitDepth = static_cast<int> (bD);
-    auto frac = bD - intBitDepth;
+    const auto bits = bitDepth.get();
 
     for (int channel = 0; channel < numChannels; ++channel)
     {
@@ -81,15 +79,12 @@ void Bitcrusher::processBlock (juce::AudioBuffer<float>& inAudio, int samplesPer
         for (int sample = 0; sample < samplesPerBlock; ++sample)
         {
             const float inputSample = channelData[sample];
-            auto y1 = getBitcrushedSample (inputSample, intBitDepth);
-            auto y2 = getBitcrushedSample (inputSample, intBitDepth + 1);
-
-            channelData[sample] = tote_bag::audio_helpers::linearInterp (y1, y2, frac);
+            channelData[sample] = getBitcrushedSample(inputSample, bits);
         }
     }
 }
 
-inline float Bitcrusher::getBitcrushedSample (float inputSample, int bits)
+inline float Bitcrusher::getBitcrushedSample (float inputSample, float bits)
 {
     const auto q = 1.0f / (powf (2.0f, bits) - 1);
 

--- a/libs/tote_bag/dsp/DigiDegraders.h
+++ b/libs/tote_bag/dsp/DigiDegraders.h
@@ -47,7 +47,7 @@ public:
 
     void setParams (float inBitDepth);
     void processBlock (juce::AudioBuffer<float>& inAudio, int samplesPerBlock, int numChannels);
-    float getBitcrushedSample (float inputSample, int bits);
+    float getBitcrushedSample (float inputSample, float bits);
 
 private:
     juce::Atomic<float> bitDepth { 16.0f };

--- a/libs/tote_bag/dsp/DigiDegraders.h
+++ b/libs/tote_bag/dsp/DigiDegraders.h
@@ -47,7 +47,25 @@ public:
 
     void setParams (float inBitDepth);
     void processBlock (juce::AudioBuffer<float>& inAudio, int samplesPerBlock, int numChannels);
-    float getBitcrushedSample (float inputSample, float bits);
+
+    /** Returns a bitcrushed sample—with a twist.
+     *
+     *  The typical calculation for a uniform bitcrusher is:
+     *
+     *  quantization = 1 / (2 ^ bits)
+     *  output = quantization * floor((input / quantization) + 0.5)
+     *
+     * This makes the quantization (nearest step) the same for negative
+     * and positive numbers.
+     *
+     * Omitting the 0.5 results in quantization (nearest lesser step) that
+     * effectively makes the signal greater for negative values and smaller
+     * for positive values.
+     *
+     * It also sounds very cool.
+     *
+     */
+    float asymmetricBitcrush (float inputSample, float bits);
 
 private:
     juce::Atomic<float> bitDepth { 16.0f };

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -426,7 +426,7 @@ void ValentineAudioProcessor::parameterChanged (const juce::String& parameter, f
                                          FFCompParameterMin[bitCrushIndex],
                                          FFCompParameterMax[bitCrushIndex],
                                          16.0f,
-                                         2.0f));
+                                         1.0f));
         if (newValue >= 1.0001f)
             crushOn.set (true);
         else

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -425,8 +425,8 @@ void ValentineAudioProcessor::parameterChanged (const juce::String& parameter, f
         bitCrush->setParams (juce::jmap (newValue,
                                          FFCompParameterMin[bitCrushIndex],
                                          FFCompParameterMax[bitCrushIndex],
-                                         17.0f,
-                                         3.0f));
+                                         16.0f,
+                                         2.0f));
         if (newValue >= 1.0001f)
             crushOn.set (true);
         else


### PR DESCRIPTION
I had bit crush on my mind, so I took a look at our bitcrush
implementation for the first time in a while. There were problems!

Valentine uses a simple method for bit crushing a signal:

`quotient = 1 / 2 ^ bits`
`output = quotient * floor(input / quotient)`

I implemented this under the assumption that `bits` needed to be an integer,
so I did some wacky stuff in order to allow for a continuous control range.
These changes dispense with that, making for a more readable and slightly more
efficient implementation. 

The work made me reflect a bit more on what this effect was doing as well.
the actual equation for uniform quantization is:

`output = quotient * floor((input / quotient) +.5)`

This correctly rounds input samples to the nearest quantization step.
What happens if we don't add the `.5`? First off, it sounds really cool
—super aggressive, adding a lot of feedback-like sustain to the signal.

This context has been added to the bitcrush function's documentation,
with the function itself renamed to be more descriptive.

Some other changes are in here as well for clarity's sake.
