### PR TITLE
Resolve implicit conversion warnings in saturator

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -44,7 +44,7 @@ DerivePointerAlignment: false
 DisableFormat: false
 ExperimentalAutoDetectBinPacking: false
 IndentCaseLabels: true
-IndentPPDirectives: BeforeHash
+IndentPPDirectives: None
 IndentWidth: 4
 IndentWrappedFunctionNames: true
 KeepEmptyLinesAtTheStartOfBlocks: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ set(SourceFiles
     libs/tote_bag/juce_gui/utilities/tbl_font.cpp
 
     libs/tote_bag/utils/macros.hpp
+    libs/tote_bag/utils/type_helpers.hpp
     )
 
 target_sources("${PROJECT_NAME}" PRIVATE ${SourceFiles})

--- a/libs/tote_bag/dsp/AudioHelpers.h
+++ b/libs/tote_bag/dsp/AudioHelpers.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include "tote_bag/utils/type_helpers.hpp"
+
 #include <algorithm>
 #include <cmath>
 
@@ -86,6 +88,26 @@ FloatType fastClip (FloatType x, FloatType minimumValue, FloatType maximumValue)
     return (x);
 }
 
+template <typename FloatType>
+constexpr std::pair<FloatType, FloatType> coshRange()
+{
+    // Copilot spat these ranges out (!) when I started typing them.
+    // I had loosely figured out the ranges to be
+    // +- 710.0 and +- 88.0 for double and float respectively.
+    if constexpr (std::is_same<FloatType, double>::value)
+    {
+        return { -710.4758600739439, 710.4758600739439 };
+    }
+    else if constexpr (std::is_same<FloatType, float>::value)
+    {
+        return { -88.3762626647949, 88.3762626647949 };
+    }
+    else
+    {
+        static_assert (type_helpers::dependent_false<FloatType>::value, "ClampedCosh only supports float types");
+    }
+}
+
 /** Returns cosh(x), clamping input beforehand to prevent overflow.
     The bounds used are found by brute force: e.g. running std::cosh with values
     increasing until overflow occurs. I am assuming here that this is well
@@ -96,10 +118,9 @@ FloatType fastClip (FloatType x, FloatType minimumValue, FloatType maximumValue)
 template <typename FloatType>
 inline FloatType ClampedCosh (FloatType x)
 {
-    static constexpr FloatType coshMin = -710.0;
-    static constexpr FloatType coshMax = 710.0;
+    const auto [min, max] = coshRange<FloatType>();
 
-    return std::cosh (std::clamp (x, coshMin, coshMax));
+    return std::cosh (std::clamp (x, min, max));
 }
 
 /** Returns the the next power of 2 greater than `x`. Returns `x` if it is a power of 2

--- a/libs/tote_bag/dsp/AudioHelpers.h
+++ b/libs/tote_bag/dsp/AudioHelpers.h
@@ -116,7 +116,7 @@ constexpr std::pair<FloatType, FloatType> coshRange()
     if aliasing becomes an issue.
  */
 template <typename FloatType>
-inline FloatType ClampedCosh (FloatType x)
+inline FloatType clampedCosh (FloatType x)
 {
     const auto [min, max] = coshRange<FloatType>();
 

--- a/libs/tote_bag/dsp/Saturation.cpp
+++ b/libs/tote_bag/dsp/Saturation.cpp
@@ -115,9 +115,14 @@ inline float Saturation::interpolatedHyperbolicTangent (float x, size_t channel)
 
 float Saturation::hyperTanFirstAntiDeriv (float x)
 {
-    return std::log (tote_bag::audio_helpers::ClampedCosh (x));
-}
+    using namespace tote_bag::audio_helpers;
 
+    // Casting to double is necessary to avoid overflow in the exponential function
+    const auto x1 = ClampedCosh (static_cast<double> (x));
+    const auto x2 = std::log (x1);
+
+    return static_cast<float> (x2);
+}
 
 //===============================================================================
 

--- a/libs/tote_bag/dsp/Saturation.cpp
+++ b/libs/tote_bag/dsp/Saturation.cpp
@@ -118,7 +118,7 @@ float Saturation::hyperTanFirstAntiDeriv (float x)
     using namespace tote_bag::audio_helpers;
 
     // Casting to double is necessary to avoid overflow in the exponential function
-    const auto x1 = ClampedCosh (static_cast<double> (x));
+    const auto x1 = clampedCosh (static_cast<double> (x));
     const auto x2 = std::log (x1);
 
     return static_cast<float> (x2);

--- a/libs/tote_bag/dsp/Saturation.h
+++ b/libs/tote_bag/dsp/Saturation.h
@@ -37,29 +37,29 @@ public:
         interpolatedHyperbolicTangent
     };
 
-    Saturation (Type sType, double asymm = 0.0);
+    Saturation (Type sType, float asymm = 0.0);
 
-    void setParams (double inSaturation);
+    void setParams (float inSaturation);
 
     void reset (double sampleRate);
 
-    inline double calcGain (double inputSample, double sat);
+    inline float calcGain (float inputSample, float sat);
 
-    inline double processSample (double inputSample, int channel, double sat);
+    inline float processSample (float inputSample, size_t channel, float sat);
 
     //==============================================================
 
-    inline double inverseHyperbolicSine (double x, double gain);
+    inline float inverseHyperbolicSine (float x, float gain);
 
-    inline float inverseHyperbolicSineInterp (float x, int channel);
+    inline float inverseHyperbolicSineInterp (float x, size_t channel);
 
     inline float sineArcTangent (float x, float gain);
 
-    inline double hyperbolicTangent (double x, double gain);
+    inline float hyperbolicTangent (float x, float gain);
 
-    inline double interpolatedHyperbolicTangent (double x, int channel);
+    inline float interpolatedHyperbolicTangent (float x, size_t channel);
 
-    inline double hyperTanFirstAntiDeriv (double x);
+    inline float hyperTanFirstAntiDeriv (float x);
 
     inline float invHypeSineAntiDeriv (float x);
 
@@ -70,13 +70,13 @@ public:
 private:
     Type saturationType;
 
-    double asymmetry { 0.0 };
+    float asymmetry { 0.0f };
 
-    const double gainRampSec { .005 };
+    const float gainRampSec { .005f };
 
-    juce::SmoothedValue<double, juce::ValueSmoothingTypes::Linear> smoothedSat { 1.0f };
-    juce::AudioBuffer<double> xState;
-    std::array<double, 2> antiderivState;
+    juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> smoothedSat { 1.0f };
+    juce::AudioBuffer<float> xState;
+    std::array<float, 2> antiderivState;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (Saturation)
 };

--- a/libs/tote_bag/utils/type_helpers.hpp
+++ b/libs/tote_bag/utils/type_helpers.hpp
@@ -1,0 +1,48 @@
+// Tote Bag Labs 2023
+
+#include <type_traits>
+
+#ifndef type_helpers_hpp
+#define type_helpers_hpp
+
+namespace tote_bag
+{
+namespace type_helpers
+{
+/** A a type that evaluates to false if instantiated.
+ * 
+ *  This is useful for static asserts that should only trigger based on conditions
+ *  evaluated using template arguments at compile time.
+ *  
+ *  Bool cannot be used in this case, as the resulting expression will always be compiled 
+ *  and hence cause an error, no matter whether the conditions for hitting the 
+ *  assert have been met or not.
+ * 
+ *  Example:
+ *
+ *  template <typename T>
+ *  void functionThatNeedsIntType()
+ *  {
+ *      if constexpr (std::is_same_v<T, int>)
+ *      {
+ *          // Do something.
+ *      }
+ *      else
+ *      {
+ *         // This will always cause a compilation error.
+ *         //static_assert(false, "This type is not supported");
+ * 
+ *         // This will only cause an error if the template is instantiated with a type other than int,
+ *         // causing this branch to be evaluated and the dependent_false to be instantiated.
+ *         static_assert(dependent_false<T>::value, "This type is not supported");
+ *      }
+ *  }
+ */
+template <typename T>
+struct dependent_false : std::false_type
+{
+};
+}
+}
+
+#endif /* type_helpers_hpp */

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -40,7 +40,7 @@ ValentineAudioProcessor::ValentineAudioProcessor()
     ffCompressor->setKnee (kneeValues[defaultRatioIndex]);
     ffCompressor->setThreshold (thresholdValues[defaultRatioIndex]);
     bitCrush->setParams (17.0);
-    saturator->setParams (.001);
+    saturator->setParams (.001f);
     boundedSaturator->setParams (boundedSatGain);
 }
 

--- a/tests/AudioHelpersTests.cpp
+++ b/tests/AudioHelpersTests.cpp
@@ -9,6 +9,8 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 
+#include <cmath>
+
 TEST_CASE ("Next power of two", "[Audio Helpers]")
 {
     // Finds the next power of two for given input
@@ -18,4 +20,17 @@ TEST_CASE ("Next power of two", "[Audio Helpers]")
     // Returns the same as input if it is a power of 2
     const int nextPowerSame = tote_bag::audio_helpers::nextPow2 (256);
     REQUIRE (nextPowerSame == 256);
+}
+
+TEST_CASE ("Clamped cosh won't blow up", "[Audio Helpers]")
+{
+    // cosh will overflow floats at ~71.0f
+    const auto floatResult = tote_bag::audio_helpers::ClampedCosh (750.0f);
+
+    REQUIRE (std::fpclassify (floatResult) == FP_NORMAL);
+
+    // cosh will overflow doubles at ~710.0
+    const auto doubleResult = tote_bag::audio_helpers::ClampedCosh (750.0);
+
+    REQUIRE (std::fpclassify (doubleResult) == FP_NORMAL);
 }

--- a/tests/AudioHelpersTests.cpp
+++ b/tests/AudioHelpersTests.cpp
@@ -25,12 +25,12 @@ TEST_CASE ("Next power of two", "[Audio Helpers]")
 TEST_CASE ("Clamped cosh won't blow up", "[Audio Helpers]")
 {
     // cosh will overflow floats at ~71.0f
-    const auto floatResult = tote_bag::audio_helpers::ClampedCosh (750.0f);
+    const auto floatResult = tote_bag::audio_helpers::clampedCosh (750.0f);
 
     REQUIRE (std::fpclassify (floatResult) == FP_NORMAL);
 
     // cosh will overflow doubles at ~710.0
-    const auto doubleResult = tote_bag::audio_helpers::ClampedCosh (750.0);
+    const auto doubleResult = tote_bag::audio_helpers::clampedCosh (750.0);
 
     REQUIRE (std::fpclassify (doubleResult) == FP_NORMAL);
 }


### PR DESCRIPTION
And so continues our crusade against warnings.

In this case, most of our warnings were implicit `float` to `double`
conversion. These were mainly resolved by amending our function interfaces to accept `float`. 

One exception is the `hyperTanFirstAntiDeriv`. This function has been
the source of overflows for a while now. Earlier I figured that the `cosh`
call was the culprit, as that function blows up for silly large numbers.
Because of this, I implemented a wrapper function that first clips input
that would cause an overflow.

One thing I neglected to consider is that the range to which input is clipped
is determined by the type in use. Originally, this was all implemented using
`double`. These changes, however, changed everything to `float`, as that is
the type we expect from calling code (maybe we can template that some time).
Doing this brought the overflows, NaN, and denormals back. 

So, I figured I could use different ranges for `float` and `double`. More about that
below. This work ended up solving the issue. `float` was now working without 
overflow...most of the time. I got another  CI failure in Windows, and figured that it 
would be best to err on the side of caution and just cast  to `double` when doing 
the antiderivative and casting back to `float` on the way out.

Nevermind the fancy `constexpr` magic  I worked to "cleanly" set those 
`clampedCosine` bounds. I learned a lot about templates, specifically how
branching works for `if constexpr` expression.

Here's what I wanted to do: create a function that returned a pair of 
float types, depending on the function's type:

```
template <typename T>
constexpr std::pair<T, T> coshRange()
{
    if constexpr (std::is_same<T, double>::value)
    {
        return { range };
    }
    else if constexpr (std::is_same<T, float>::value)
    {
        return { a different range };
    }
    else
    {
        static_assert (false, "ClampedCosh only supports float types");
    }
}

```

I was extremely confused when I saw the `static_assert` failing, even when instantiating a 
function with an accepted type.

Some searching lead me to this answer on [Stack Overflow](https://stackoverflow.com/questions/68526152/c-static-assert-fails-on-both-branches-of-an-if-constexpr-statement), which I understand as meaning: a `static_assert` is always compiled. Therefore,
writing something like `static_assert(false,"message")` will always fail.

The solution is to, with the help of `type_traits`, create a helper type that always evaluates to false and, most importantly, only is compiled when instantiated:

```
template <typename T>
struct dependent_false : std::false_type
{
};
```

Now we can write that else branch as:

```
static_assert (dependent_false<T>, "ClampedCosh only supports float types");
```

And the static_assert will correctly (successfully?) fail if the function was instantiated with an 
incompatible type.

After all of this, I ended up not using the specialization that all this fuss was for—as I mentioned above,
I still got some overflows and ended up doing that part of the calculation with `double`. But 
it was a fun bit of learning that I've chosen to keep in.