### PR TITLE
Fix saturation gain scaling

### DIFF
--- a/libs/tote_bag/dsp/AudioHelpers.h
+++ b/libs/tote_bag/dsp/AudioHelpers.h
@@ -96,11 +96,11 @@ constexpr std::pair<FloatType, FloatType> coshRange()
     // +- 710.0 and +- 88.0 for double and float respectively.
     if constexpr (std::is_same<FloatType, double>::value)
     {
-        return { -710.4758600739439, 710.4758600739439 };
+        return { -710.0, 710.0 };
     }
     else if constexpr (std::is_same<FloatType, float>::value)
     {
-        return { -88.3762626647949, 88.3762626647949 };
+        return { -88.0f, 88.0f };
     }
     else
     {

--- a/libs/tote_bag/dsp/Saturation.cpp
+++ b/libs/tote_bag/dsp/Saturation.cpp
@@ -136,19 +136,19 @@ inline float Saturation::processSample (float inputSample, size_t channel, float
     switch (saturationType)
     {
         case Type::inverseHyperbolicSine:
-            return inverseHyperbolicSine (inputSample * gain) / gain;
+            return inverseHyperbolicSine (inputSample * gain) * compensationGain<inverseHyperbolicSineTag> (gain);
 
         case Type::sineArcTangent:
             return sineArcTangent (inputSample, gain);
 
         case Type::hyperbolicTangent:
-            return hyperbolicTangent (inputSample * gain) / gain;
+            return hyperbolicTangent (inputSample * gain) * compensationGain<hyperbolicTangentTag> (gain);
 
         case Type::inverseHyperbolicSineInterp:
-            return inverseHyperbolicSineInterp (inputSample * gain, channel) / gain;
+            return inverseHyperbolicSineInterp (inputSample * gain, channel) * compensationGain<inverseHyperbolicSineTag> (gain);
 
         case Type::interpolatedHyperbolicTangent:
-            return interpolatedHyperbolicTangent (inputSample * gain, channel) / gain;
+            return interpolatedHyperbolicTangent (inputSample * gain, channel) * compensationGain<hyperbolicTangentTag> (gain);
 
         default:
             //somehow the distortion type was not set. It must be set!

--- a/libs/tote_bag/dsp/Saturation.cpp
+++ b/libs/tote_bag/dsp/Saturation.cpp
@@ -82,10 +82,9 @@ inline float Saturation::sineArcTangent (float x, float gain)
     return (xScaled / sqrt (1.f + xScaled * xScaled)) / gain;
 }
 
-inline float Saturation::hyperbolicTangent (float x, float gain)
+inline float Saturation::hyperbolicTangent (float x)
 {
-    auto xScaled = x * gain;
-    return std::tanh (xScaled) / gain;
+    return std::tanh (x);
 }
 
 float Saturation::hyperTanFirstAntiDeriv (float x)
@@ -110,7 +109,7 @@ inline float Saturation::interpolatedHyperbolicTangent (float x, size_t channel)
     if (abs (diff) < 0.001)
     {
         auto input = (x + stateSample) / 2.f;
-        output = hyperbolicTangent (input, 1.0f);
+        output = hyperbolicTangent (input);
     }
     else
     {
@@ -143,7 +142,7 @@ inline float Saturation::processSample (float inputSample, size_t channel, float
             return sineArcTangent (inputSample, gain);
 
         case Type::hyperbolicTangent:
-            return hyperbolicTangent (inputSample, gain);
+            return hyperbolicTangent (inputSample * gain) / gain;
 
         case Type::inverseHyperbolicSineInterp:
             return inverseHyperbolicSineInterp (inputSample * gain, channel) / gain;

--- a/libs/tote_bag/dsp/Saturation.cpp
+++ b/libs/tote_bag/dsp/Saturation.cpp
@@ -88,6 +88,17 @@ inline float Saturation::hyperbolicTangent (float x, float gain)
     return std::tanh (xScaled) / gain;
 }
 
+float Saturation::hyperTanFirstAntiDeriv (float x)
+{
+    using namespace tote_bag::audio_helpers;
+
+    // Casting to double is necessary to avoid overflow in the exponential function
+    const auto x1 = clampedCosh (static_cast<double> (x));
+    const auto x2 = std::log (x1);
+
+    return static_cast<float> (x2);
+}
+
 inline float Saturation::interpolatedHyperbolicTangent (float x, size_t channel)
 
 {
@@ -110,17 +121,6 @@ inline float Saturation::interpolatedHyperbolicTangent (float x, size_t channel)
     antiderivState[channel] = antiDeriv;
 
     return output;
-}
-
-float Saturation::hyperTanFirstAntiDeriv (float x)
-{
-    using namespace tote_bag::audio_helpers;
-
-    // Casting to double is necessary to avoid overflow in the exponential function
-    const auto x1 = clampedCosh (static_cast<double> (x));
-    const auto x2 = std::log (x1);
-
-    return static_cast<float> (x2);
 }
 
 //===============================================================================

--- a/libs/tote_bag/dsp/Saturation.cpp
+++ b/libs/tote_bag/dsp/Saturation.cpp
@@ -49,6 +49,11 @@ inline float Saturation::inverseHyperbolicSine (float x, float gain)
     return log (xScaled + sqrt (xScaled * xScaled + 1.0f)) / gain;
 }
 
+inline float Saturation::invHypeSineAntiDeriv (float x)
+{
+    return x * inverseHyperbolicSine (x, 1.0f) - sqrt (x * x + 1.0f);
+}
+
 inline float Saturation::inverseHyperbolicSineInterp (float x, size_t channel)
 {
     auto stateSample = xState.getSample (static_cast<int> (channel), 0);
@@ -70,11 +75,6 @@ inline float Saturation::inverseHyperbolicSineInterp (float x, size_t channel)
     antiderivState[channel] = antiDeriv;
 
     return output;
-}
-
-inline float Saturation::invHypeSineAntiDeriv (float x)
-{
-    return x * inverseHyperbolicSine (x, 1.0f) - sqrt (x * x + 1.0f);
 }
 
 inline float Saturation::sineArcTangent (float x, float gain)

--- a/libs/tote_bag/dsp/Saturation.cpp
+++ b/libs/tote_bag/dsp/Saturation.cpp
@@ -43,15 +43,14 @@ inline float Saturation::calcGain (float inputSample, float sat)
 }
 
 //===============================================================================
-inline float Saturation::inverseHyperbolicSine (float x, float gain)
+inline float Saturation::inverseHyperbolicSine (float x)
 {
-    auto xScaled = x * gain;
-    return log (xScaled + sqrt (xScaled * xScaled + 1.0f)) / gain;
+    return log (x + sqrt (x * x + 1.0f));
 }
 
 inline float Saturation::invHypeSineAntiDeriv (float x)
 {
-    return x * inverseHyperbolicSine (x, 1.0f) - sqrt (x * x + 1.0f);
+    return x * inverseHyperbolicSine (x) - sqrt (x * x + 1.0f);
 }
 
 inline float Saturation::inverseHyperbolicSineInterp (float x, size_t channel)
@@ -64,7 +63,7 @@ inline float Saturation::inverseHyperbolicSineInterp (float x, size_t channel)
     if (abs (diff) < 0.001f)
     {
         auto input = (x + stateSample) / 2.f;
-        output = inverseHyperbolicSine (input, 1.0f);
+        output = inverseHyperbolicSine (input);
     }
     else
     {
@@ -138,7 +137,7 @@ inline float Saturation::processSample (float inputSample, size_t channel, float
     switch (saturationType)
     {
         case Type::inverseHyperbolicSine:
-            return inverseHyperbolicSine (inputSample, gain);
+            return inverseHyperbolicSine (inputSample * gain) / gain;
 
         case Type::sineArcTangent:
             return sineArcTangent (inputSample, gain);

--- a/libs/tote_bag/dsp/Saturation.h
+++ b/libs/tote_bag/dsp/Saturation.h
@@ -57,7 +57,7 @@ public:
 
     inline float sineArcTangent (float x, float gain);
 
-    inline float hyperbolicTangent (float x, float gain);
+    inline float hyperbolicTangent (float x);
 
     inline float hyperTanFirstAntiDeriv (float x);
 

--- a/libs/tote_bag/dsp/Saturation.h
+++ b/libs/tote_bag/dsp/Saturation.h
@@ -59,9 +59,9 @@ public:
 
     inline float hyperbolicTangent (float x, float gain);
 
-    inline float interpolatedHyperbolicTangent (float x, size_t channel);
-
     inline float hyperTanFirstAntiDeriv (float x);
+
+    inline float interpolatedHyperbolicTangent (float x, size_t channel);
 
     //==============================================================
 

--- a/libs/tote_bag/dsp/Saturation.h
+++ b/libs/tote_bag/dsp/Saturation.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include "tote_bag/utils/type_helpers.hpp"
+
 #include <juce_audio_basics/juce_audio_basics.h>
 #include <juce_dsp/juce_dsp.h>
 
@@ -68,6 +70,28 @@ public:
     void processBlock (juce::dsp::AudioBlock<float>& inAudio);
 
 private:
+  // tags - first step towards a templated version of this class
+  struct inverseHyperbolicSineTag {};
+  struct hyperbolicTangentTag {};
+
+  template <typename SaturationType, typename FloatType>
+  auto compensationGain(FloatType inputGain)
+  {
+    if constexpr (std::is_same<SaturationType, inverseHyperbolicSineTag>::value)
+    {
+      return static_cast<FloatType>(1.0) / inverseHyperbolicSine(inputGain);
+    }
+    else if constexpr (std::is_same<SaturationType, hyperbolicTangentTag>::value)
+    {
+      return static_cast<FloatType>(1.0) / hyperbolicTangent(inputGain);
+    }
+    else
+    {
+      static_assert(tote_bag::type_helpers::dependent_false<SaturationType>::value, "Unsupported saturation type.");
+    }
+  }
+
+
     Type saturationType;
 
     float asymmetry { 0.0f };

--- a/libs/tote_bag/dsp/Saturation.h
+++ b/libs/tote_bag/dsp/Saturation.h
@@ -51,6 +51,8 @@ public:
 
     inline float inverseHyperbolicSine (float x, float gain);
 
+    inline float invHypeSineAntiDeriv (float x);
+
     inline float inverseHyperbolicSineInterp (float x, size_t channel);
 
     inline float sineArcTangent (float x, float gain);
@@ -60,8 +62,6 @@ public:
     inline float interpolatedHyperbolicTangent (float x, size_t channel);
 
     inline float hyperTanFirstAntiDeriv (float x);
-
-    inline float invHypeSineAntiDeriv (float x);
 
     //==============================================================
 

--- a/libs/tote_bag/dsp/Saturation.h
+++ b/libs/tote_bag/dsp/Saturation.h
@@ -49,7 +49,7 @@ public:
 
     //==============================================================
 
-    inline float inverseHyperbolicSine (float x, float gain);
+    inline float inverseHyperbolicSine (float x);
 
     inline float invHypeSineAntiDeriv (float x);
 


### PR DESCRIPTION
As described in the attached issue, turning `Saturation` up worked as intended,
but _also_ made the output quieter. This is because of the way gain was being 
normalized. This is because of the overly simplistic normalization used in saturation
processing. 

Here's how we were doing it:

`y = f(x * gain) / gain`

This works in that it keeps the signal from getting too loud and hence requiring manual
gain adjustment when turning up `Saturation`. This doesn't actually work because the 
the function is, of course, nonlinear. The function's output won't increase as much as
gain does. Dividing the output of this function by `gain`, then, will make the output 
quieter.

What we need is for the gain compensation to ease up for larger `gain` inputs. 

The following works a lot better:

`y = f(x * gain) / f(gain)`

I probably saw this in a paper or book before and forgot to apply it.
And then, when I was pondering this issue, I asked `copilot` to write me a function
that would find the correct compensation gain for an inverse hyperbolic sine.

The answer was basically what's shown above.

There's also some formatting changes in here, mostly to make the code more readable.