### PR TITLE
Saturation cleanups

### DIFF
--- a/libs/tote_bag/dsp/Saturation.cpp
+++ b/libs/tote_bag/dsp/Saturation.cpp
@@ -55,7 +55,7 @@ inline float Saturation::inverseHyperbolicSineInterp (float x, size_t channel)
 
     auto antiDeriv = invHypeSineAntiDeriv (x);
     auto output = 0.0f;
-    if (abs (diff) < 0.001f)
+    if (abs (diff) < 1.0e-4f)
     {
         auto input = (x + stateSample) / 2.f;
         output = std::asinh (input);

--- a/libs/tote_bag/dsp/Saturation.cpp
+++ b/libs/tote_bag/dsp/Saturation.cpp
@@ -43,14 +43,9 @@ inline float Saturation::calcGain (float inputSample, float sat)
 }
 
 //===============================================================================
-inline float Saturation::inverseHyperbolicSine (float x)
-{
-    return log (x + sqrt (x * x + 1.0f));
-}
-
 inline float Saturation::invHypeSineAntiDeriv (float x)
 {
-    return x * inverseHyperbolicSine (x) - sqrt (x * x + 1.0f);
+    return x * std::asinh (x) - sqrt (x * x + 1.0f);
 }
 
 inline float Saturation::inverseHyperbolicSineInterp (float x, size_t channel)
@@ -63,7 +58,7 @@ inline float Saturation::inverseHyperbolicSineInterp (float x, size_t channel)
     if (abs (diff) < 0.001f)
     {
         auto input = (x + stateSample) / 2.f;
-        output = inverseHyperbolicSine (input);
+        output = std::asinh (input);
     }
     else
     {
@@ -136,7 +131,7 @@ inline float Saturation::processSample (float inputSample, size_t channel, float
     switch (saturationType)
     {
         case Type::inverseHyperbolicSine:
-            return inverseHyperbolicSine (inputSample * gain) * compensationGain<inverseHyperbolicSineTag> (gain);
+            return std::asinh (inputSample * gain) * compensationGain<inverseHyperbolicSineTag> (gain);
 
         case Type::sineArcTangent:
             return sineArcTangent (inputSample, gain);

--- a/libs/tote_bag/dsp/Saturation.cpp
+++ b/libs/tote_bag/dsp/Saturation.cpp
@@ -77,11 +77,6 @@ inline float Saturation::sineArcTangent (float x, float gain)
     return (xScaled / sqrt (1.f + xScaled * xScaled)) / gain;
 }
 
-inline float Saturation::hyperbolicTangent (float x)
-{
-    return std::tanh (x);
-}
-
 float Saturation::hyperTanFirstAntiDeriv (float x)
 {
     using namespace tote_bag::audio_helpers;
@@ -104,7 +99,7 @@ inline float Saturation::interpolatedHyperbolicTangent (float x, size_t channel)
     if (abs (diff) < 0.001)
     {
         auto input = (x + stateSample) / 2.f;
-        output = hyperbolicTangent (input);
+        output = std::tanh (input);
     }
     else
     {
@@ -137,7 +132,7 @@ inline float Saturation::processSample (float inputSample, size_t channel, float
             return sineArcTangent (inputSample, gain);
 
         case Type::hyperbolicTangent:
-            return hyperbolicTangent (inputSample * gain) * compensationGain<hyperbolicTangentTag> (gain);
+            return std::tanh (inputSample * gain) * compensationGain<hyperbolicTangentTag> (gain);
 
         case Type::inverseHyperbolicSineInterp:
             return inverseHyperbolicSineInterp (inputSample * gain, channel) * compensationGain<inverseHyperbolicSineTag> (gain);

--- a/libs/tote_bag/dsp/Saturation.cpp
+++ b/libs/tote_bag/dsp/Saturation.cpp
@@ -96,7 +96,7 @@ inline float Saturation::interpolatedHyperbolicTangent (float x, size_t channel)
     auto output = 0.0f;
     auto antiDeriv = hyperTanFirstAntiDeriv (x);
 
-    if (abs (diff) < 0.001)
+    if (abs (diff) < 1.0e-6f)
     {
         auto input = (x + stateSample) / 2.f;
         output = std::tanh (input);

--- a/libs/tote_bag/dsp/Saturation.h
+++ b/libs/tote_bag/dsp/Saturation.h
@@ -51,8 +51,6 @@ public:
 
     //==============================================================
 
-    inline float inverseHyperbolicSine (float x);
-
     inline float invHypeSineAntiDeriv (float x);
 
     inline float inverseHyperbolicSineInterp (float x, size_t channel);
@@ -83,7 +81,7 @@ private:
     {
         if constexpr (std::is_same<SaturationType, inverseHyperbolicSineTag>::value)
         {
-            return static_cast<FloatType> (1.0) / inverseHyperbolicSine (inputGain);
+            return static_cast<FloatType> (1.0) / std::asinh (inputGain);
         }
         else if constexpr (std::is_same<SaturationType, hyperbolicTangentTag>::value)
         {

--- a/libs/tote_bag/dsp/Saturation.h
+++ b/libs/tote_bag/dsp/Saturation.h
@@ -70,27 +70,30 @@ public:
     void processBlock (juce::dsp::AudioBlock<float>& inAudio);
 
 private:
-  // tags - first step towards a templated version of this class
-  struct inverseHyperbolicSineTag {};
-  struct hyperbolicTangentTag {};
+    // tags - first step towards a templated version of this class
+    struct inverseHyperbolicSineTag
+    {
+    };
+    struct hyperbolicTangentTag
+    {
+    };
 
-  template <typename SaturationType, typename FloatType>
-  auto compensationGain(FloatType inputGain)
-  {
-    if constexpr (std::is_same<SaturationType, inverseHyperbolicSineTag>::value)
+    template <typename SaturationType, typename FloatType>
+    auto compensationGain (FloatType inputGain)
     {
-      return static_cast<FloatType>(1.0) / inverseHyperbolicSine(inputGain);
+        if constexpr (std::is_same<SaturationType, inverseHyperbolicSineTag>::value)
+        {
+            return static_cast<FloatType> (1.0) / inverseHyperbolicSine (inputGain);
+        }
+        else if constexpr (std::is_same<SaturationType, hyperbolicTangentTag>::value)
+        {
+            return static_cast<FloatType> (1.0) / hyperbolicTangent (inputGain);
+        }
+        else
+        {
+            static_assert (tote_bag::type_helpers::dependent_false<SaturationType>::value, "Unsupported saturation type.");
+        }
     }
-    else if constexpr (std::is_same<SaturationType, hyperbolicTangentTag>::value)
-    {
-      return static_cast<FloatType>(1.0) / hyperbolicTangent(inputGain);
-    }
-    else
-    {
-      static_assert(tote_bag::type_helpers::dependent_false<SaturationType>::value, "Unsupported saturation type.");
-    }
-  }
-
 
     Type saturationType;
 

--- a/libs/tote_bag/dsp/Saturation.h
+++ b/libs/tote_bag/dsp/Saturation.h
@@ -57,8 +57,6 @@ public:
 
     inline float sineArcTangent (float x, float gain);
 
-    inline float hyperbolicTangent (float x);
-
     inline float hyperTanFirstAntiDeriv (float x);
 
     inline float interpolatedHyperbolicTangent (float x, size_t channel);
@@ -85,7 +83,7 @@ private:
         }
         else if constexpr (std::is_same<SaturationType, hyperbolicTangentTag>::value)
         {
-            return static_cast<FloatType> (1.0) / hyperbolicTangent (inputGain);
+            return static_cast<FloatType> (1.0) / std::tanh (inputGain);
         }
         else
         {

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -40,7 +40,7 @@ ValentineAudioProcessor::ValentineAudioProcessor()
     ffCompressor->setKnee (kneeValues[defaultRatioIndex]);
     ffCompressor->setThreshold (thresholdValues[defaultRatioIndex]);
     bitCrush->setParams (17.0);
-    saturator->setParams (.001f);
+    saturator->setParams (kMinSaturationGain);
     boundedSaturator->setParams (boundedSatGain);
 }
 

--- a/src/ValentineParameters.h
+++ b/src/ValentineParameters.h
@@ -209,5 +209,5 @@ static constexpr std::array<float, 5> thresholdValues = {
     -10.0f,
 };
 
-static constexpr float kMinSaturationGain = .001f;
+static constexpr float kMinSaturationGain = 1.0f;
 static constexpr float kMaxSaturationGain = 30.0f;


### PR DESCRIPTION
These changes aim to make our interpolated clippers sound a little
bit better. This is accomplished, in general, by lowering the tolerance
for when we decide to use the non-interpolated version to prevent a 
divide by zero.

My reasoning here is not rigorous: I figure that, as the conventional
calculation is only there for when the system get into a bad state otherwise,
we should use the interpolated version as much as possible.

This led me to replace the hand rolled calculation of the interpolated
hyperbolic sine with the standard library implementation. For whatever
reason, it sounded better when lowering the tolerance point than
the calculation I had been using. Either way, I had to choose a tolerance
a bit higher than what I thought would be necessary—a sign that I'm
doing something wrong? Possibly!

Perhaps this would work better for double?

Similar changes were made for the interpolated hyperbolic sine, which
already uses the standard library `tanh` but...wrapped for some reason.
I was able to lower the tolerance point a bit lower, closer to the actual
epsilon for `float`.