### PR TITLE
Rename piecewiseLinearInterpolate to piecewiseRemap

### DIFF
--- a/libs/tote_bag/utils/tbl_math.hpp
+++ b/libs/tote_bag/utils/tbl_math.hpp
@@ -49,20 +49,22 @@ std::pair<ValueType, ValueType>
     return std::make_pair (inputRange[indices.first], inputRange[indices.second]);
 }
 
-/** Interpolates a value from one range of the other, using sections corresponding to
+/** Remaps a value from one range of the other, using sections corresponding to
  *  the upper and lower bounds of the input value as found in the input range.
  */
 template <typename ValueType, size_t ArraySize>
-ValueType piecewiseLinearInterpolate (const std::array<ValueType, ArraySize> inputRange,
-                                      const std::array<ValueType, ArraySize> outputRange,
-                                      const ValueType input)
+ValueType piecewiseRemap (const std::array<ValueType, ArraySize> inputSegments,
+                          const std::array<ValueType, ArraySize> outputSegments,
+                          const ValueType input)
 {
-    const auto [lowerBound, upperBound] = findNearestIndices (inputRange, input);
-    const auto normalizedInput = (input - inputRange[lowerBound])
-                                 / (inputRange[upperBound] - inputRange[lowerBound]);
+    const auto [lowerBound, upperBound] = findNearestIndices (inputSegments, input);
+    // clang-format off
+    const auto normalizedInput = (input - inputSegments[lowerBound])
+                               / (inputSegments[upperBound] - inputSegments[lowerBound]);
+    // clang-format on
 
-    return outputRange[lowerBound]
-           + (outputRange[upperBound] - outputRange[lowerBound]) * normalizedInput;
+    return outputSegments[lowerBound]
+           + (outputSegments[upperBound] - outputSegments[lowerBound]) * normalizedInput;
 }
 
 } // namespace math

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -41,16 +41,14 @@ ValentineAudioProcessor::ValentineAudioProcessor()
         FFCompParameterDefaults[static_cast<size_t> (VParameter::ratio)];
     ffCompressor->setRatio (defaultRatio);
 
-    const auto kneeValue =
-        tote_bag::math::piecewiseLinearInterpolate (kRatioControlPoints,
-                                                    kKneeControlPoints,
-                                                    defaultRatio);
+    const auto kneeValue = tote_bag::math::piecewiseRemap (kRatioControlPoints,
+                                                           kKneeControlPoints,
+                                                           defaultRatio);
     ffCompressor->setKnee (kneeValue);
 
-    const auto thresholdValue =
-        tote_bag::math::piecewiseLinearInterpolate (kRatioControlPoints,
-                                                    kThresholdControlPoints,
-                                                    defaultRatio);
+    const auto thresholdValue = tote_bag::math::piecewiseRemap (kRatioControlPoints,
+                                                                kThresholdControlPoints,
+                                                                defaultRatio);
     ffCompressor->setThreshold (thresholdValue);
 
     bitCrush->setParams (17.0);
@@ -492,14 +490,13 @@ void ValentineAudioProcessor::parameterChanged (const juce::String& parameter,
 
         ffCompressor->setRatio (newValue);
 
-        auto kneeValue = tote_bag::math::piecewiseLinearInterpolate (kRatioControlPoints,
-                                                                     kKneeControlPoints,
-                                                                     newValue);
+        auto kneeValue = tote_bag::math::piecewiseRemap (kRatioControlPoints,
+                                                         kKneeControlPoints,
+                                                         newValue);
         ffCompressor->setKnee (kneeValue);
-        auto thresholdValue =
-            tote_bag::math::piecewiseLinearInterpolate (kRatioControlPoints,
-                                                        kThresholdControlPoints,
-                                                        newValue);
+        auto thresholdValue = tote_bag::math::piecewiseRemap (kRatioControlPoints,
+                                                              kThresholdControlPoints,
+                                                              newValue);
 
         ffCompressor->setThreshold (thresholdValue);
     }

--- a/tests/MathTests.cpp
+++ b/tests/MathTests.cpp
@@ -86,7 +86,7 @@ TEST_CASE ("piecewiseLinearInterpolation - basics", "[Math]")
     {
         const std::array<float, 5> inputRange = {0.0f, 1.0f, 2.0f, 3.0f, 5.0f};
         const std::array<float, 5> outputRange = {10.0f, 20.0f, 30.0f, 40.0f, 50.0f};
-        const auto result = piecewiseLinearInterpolate (inputRange, outputRange, 1.5f);
+        const auto result = piecewiseRemap (inputRange, outputRange, 1.5f);
         REQUIRE (result == 25.0f);
     }
 
@@ -94,7 +94,7 @@ TEST_CASE ("piecewiseLinearInterpolation - basics", "[Math]")
     {
         const std::array<float, 5> inputRange = {0.0f, 1.0f, 2.0f, 3.0f, 5.0f};
         const std::array<float, 5> outputRange = {50.0f, 40.0f, 30.0f, 20.0f, 10.0f};
-        const auto result = piecewiseLinearInterpolate (inputRange, outputRange, 1.5f);
+        const auto result = piecewiseRemap (inputRange, outputRange, 1.5f);
         REQUIRE (result == 35.0f);
     }
 
@@ -102,7 +102,7 @@ TEST_CASE ("piecewiseLinearInterpolation - basics", "[Math]")
     {
         const std::array<float, 5> inputRange = {0.0f, 1.0f, 2.0f, 3.0f, 5.0f};
         const std::array<float, 5> outputRange = {-10.0f, -20.0f, -30.0f, -40.0f, -50.0f};
-        const auto result = piecewiseLinearInterpolate (inputRange, outputRange, 1.5f);
+        const auto result = piecewiseRemap (inputRange, outputRange, 1.5f);
         REQUIRE (result == -25.0f);
     }
 
@@ -110,7 +110,7 @@ TEST_CASE ("piecewiseLinearInterpolation - basics", "[Math]")
     {
         const std::array<float, 5> inputRange = {0.0f, 1.0f, 2.0f, 3.0f, 5.0f};
         const std::array<float, 5> outputRange = {-10.0f, -20.0f, -30.0f, -40.0f, -50.0f};
-        const auto result = piecewiseLinearInterpolate (inputRange, outputRange, 3.0f);
+        const auto result = piecewiseRemap (inputRange, outputRange, 3.0f);
         REQUIRE (result == -40.0f);
     }
 }


### PR DESCRIPTION
I thought of better names while writing about the changes that introduced
`piecewiseLinearInterpolate`. Now it's called `piecewiseRemap`.