### PR TITLE
Tweak Output Clip

### DIFF
--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -63,7 +63,6 @@ ValentineAudioProcessor::ValentineAudioProcessor()
 
     bitCrush->setParams (17.0);
     saturator->setParams (kMinSaturationGain);
-    boundedSaturator->setParams (boundedSatGain);
 }
 
 ValentineAudioProcessor::~ValentineAudioProcessor()
@@ -584,6 +583,7 @@ void ValentineAudioProcessor::initializeDSP()
         std::make_unique<Saturation> (Saturation::Type::inverseHyperbolicSineInterp, .6f);
 
     boundedSaturator = std::make_unique<Saturation> (Saturation::Type::hyperbolicTangent);
+    boundedSaturator->setParams (detail::kNeg4_5dbGain);
 
     oversampler =
         std::make_unique<Oversampling> (2,

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -14,6 +14,16 @@
 #include "tote_bag/utils/tbl_math.hpp"
 
 //==============================================================================
+
+// TODO: maybe remove once final clipper gain is decided. Or move
+// if it seems like a good idea to store these as general constants.
+namespace detail
+{
+inline constexpr float kNeg3dbGain = 0.7079457844f;
+inline constexpr float kNeg6dbGain = 0.5011872336f;
+inline constexpr float kNeg4_5dbGain = 0.5956621435f;
+}
+
 ValentineAudioProcessor::ValentineAudioProcessor()
 #ifndef JucePlugin_PreferredChannelConfigurations
     : AudioProcessor (BusesProperties()


### PR DESCRIPTION
These changes lower the gain going into Valentine's final
clipping section. This makes gain matching a little trickier for
loud input (overs are more likely), but it allows for a cleaner, more
dynamic sound. The tools are still there to make it totally nasty, if needed.

I also added some constants to quickly try different gain settings at the 
output clipper stage. By release, these should be removed.