### PR TITLE
59 correctly initialize bits

### DIFF
--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -463,8 +463,8 @@ void ValentineAudioProcessor::parameterChanged (const juce::String& parameter,
         bitCrush->setParams (juce::jmap (newValue,
                                          FFCompParameterMin[bitCrushIndex],
                                          FFCompParameterMax[bitCrushIndex],
-                                         16.0f,
-                                         1.0f));
+                                         kMinBits,
+                                         kMaxBits));
         if (newValue >= 1.0001f)
             crushOn.set (true);
         else

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -61,7 +61,7 @@ ValentineAudioProcessor::ValentineAudioProcessor()
                                                                 defaultRatio);
     ffCompressor->setThreshold (thresholdValue);
 
-    bitCrush->setParams (17.0);
+    bitCrush->setParams (kMaxBits);
     saturator->setParams (kMinSaturationGain);
 }
 

--- a/src/ValentineParameters.h
+++ b/src/ValentineParameters.h
@@ -36,6 +36,9 @@ const size_t getParameterIndex (VParameter param)
     return static_cast<size_t> (param);
 }
 
+inline constexpr float kMinBits = 1.0f;
+inline constexpr float kMaxBits = 16.0f;
+
 inline constexpr float kMinSaturationGain = 1.0f;
 inline constexpr float kMaxSaturationGain = 30.0f;
 


### PR DESCRIPTION
These changes introduce constants for bit crush min/max values,
and correctly initializes the bitcrusher to 16 bits when Valentine starts.