### PR TITLE
Fix param setting for crush

### DIFF
--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -463,8 +463,8 @@ void ValentineAudioProcessor::parameterChanged (const juce::String& parameter,
         bitCrush->setParams (juce::jmap (newValue,
                                          FFCompParameterMin[bitCrushIndex],
                                          FFCompParameterMax[bitCrushIndex],
-                                         kMinBits,
-                                         kMaxBits));
+                                         kMaxBits,
+                                         kMinBits));
         if (newValue >= 1.0001f)
             crushOn.set (true);
         else


### PR DESCRIPTION
- https://github.com/tote-bag-labs/valentine/pull/67

resulted in bit crush values to be incorrectly mapped during parameter changes
(I reversed them, lol). These changes fix this.