### PR TITLE
Output clip param

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Parameters
 - **Ratio**: sets the compression ratio. "Infinity" is more like 1000:1. Increasing this also increases the threshold and decreases the knee.
 - **Attack**: sets compression attack time.
 - **Release**: sets compression release time.
-- **Saturate**: increases the amount of saturation.
+- **Saturate**: sets the amount of gain applied to signal before Valentine's waveshaper. This gain is compensated to prevent a huge volume boost
+when you just want more dirt. Note: at `0%` signal is actually attenuated before the waveshaper, allowing for a cleaner sound when needed.
 - **Output**: sets the wet signal's output gain before mix.
 - **Mix**:  increases the amount of wet signal in the processor's output.
 - **Bypass**: bypasses all processing.

--- a/libs/tote_bag/dsp/Saturation.cpp
+++ b/libs/tote_bag/dsp/Saturation.cpp
@@ -27,7 +27,8 @@ void Saturation::reset (double sampleRate)
     if (xState.getNumChannels() > 0)
         xState.clear();
 
-    else if (saturationType == Type::inverseHyperbolicSineInterp || saturationType == Type::interpolatedHyperbolicTangent)
+    else if (saturationType == Type::inverseHyperbolicSineInterp
+             || saturationType == Type::interpolatedHyperbolicTangent)
     {
         xState.setSize (2, 1);
         xState.clear();
@@ -39,7 +40,10 @@ void Saturation::reset (double sampleRate)
 
 inline float Saturation::calcGain (float inputSample, float sat)
 {
-    return ((inputSample >= 0.0f && asymmetry > 0.0f) || (inputSample < 0.0f && asymmetry < 0.0f)) ? sat * (1.0f + 4.0f * abs (asymmetry)) : sat;
+    return ((inputSample >= 0.0f && asymmetry > 0.0f)
+            || (inputSample < 0.0f && asymmetry < 0.0f))
+               ? sat * (1.0f + 4.0f * abs (asymmetry))
+               : sat;
 }
 
 //===============================================================================
@@ -126,19 +130,23 @@ inline float Saturation::processSample (float inputSample, size_t channel, float
     switch (saturationType)
     {
         case Type::inverseHyperbolicSine:
-            return std::asinh (inputSample * gain) * compensationGain<inverseHyperbolicSineTag> (gain);
+            return std::asinh (inputSample * gain)
+                   * compensationGain<inverseHyperbolicSineTag> (gain);
 
         case Type::sineArcTangent:
             return sineArcTangent (inputSample, gain);
 
         case Type::hyperbolicTangent:
-            return std::tanh (inputSample * gain) * compensationGain<hyperbolicTangentTag> (gain);
+            return std::tanh (inputSample * gain)
+                   * compensationGain<hyperbolicTangentTag> (gain);
 
         case Type::inverseHyperbolicSineInterp:
-            return inverseHyperbolicSineInterp (inputSample * gain, channel) * compensationGain<inverseHyperbolicSineTag> (gain);
+            return inverseHyperbolicSineInterp (inputSample * gain, channel)
+                   * compensationGain<inverseHyperbolicSineTag> (gain);
 
         case Type::interpolatedHyperbolicTangent:
-            return interpolatedHyperbolicTangent (inputSample * gain, channel) * compensationGain<hyperbolicTangentTag> (gain);
+            return interpolatedHyperbolicTangent (inputSample * gain, channel)
+                   * compensationGain<hyperbolicTangentTag> (gain);
 
         default:
             //somehow the distortion type was not set. It must be set!

--- a/libs/tote_bag/dsp/Saturation.cpp
+++ b/libs/tote_bag/dsp/Saturation.cpp
@@ -15,6 +15,9 @@ Saturation::Saturation (Type sType, float asymm)
     : saturationType (sType)
     , asymmetry (asymm)
 {
+    // Stereo. TODO: don't use AudioBuffer. Refactor this so
+    // we have state when we need it.
+    xState.setSize (2, 1);
 }
 
 void Saturation::setParams (float inSaturation)
@@ -24,18 +27,14 @@ void Saturation::setParams (float inSaturation)
 
 void Saturation::reset (double sampleRate)
 {
-    if (xState.getNumChannels() > 0)
-        xState.clear();
-
-    else if (saturationType == Type::inverseHyperbolicSineInterp
-             || saturationType == Type::interpolatedHyperbolicTangent)
-    {
-        xState.setSize (2, 1);
-        xState.clear();
-        antiderivState.fill (0.0);
-    }
-
     smoothedSat.reset (sampleRate, gainRampSec);
+    clearBuffers();
+}
+
+void Saturation::clearBuffers()
+{
+    xState.clear();
+    antiderivState.fill (0.0);
 }
 
 inline float Saturation::calcGain (float inputSample, float sat)

--- a/libs/tote_bag/dsp/Saturation.h
+++ b/libs/tote_bag/dsp/Saturation.h
@@ -122,6 +122,7 @@ private:
 
     juce::SmoothedValue<float, juce::ValueSmoothingTypes::Linear> smoothedSat {1.0f};
     juce::AudioBuffer<float> xState;
+    // I guess we're assuming first order ADAA, stereo here.
     std::array<float, 2> antiderivState;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (Saturation)

--- a/libs/tote_bag/dsp/Saturation.h
+++ b/libs/tote_bag/dsp/Saturation.h
@@ -92,7 +92,7 @@ private:
         if constexpr (std::is_same<SaturationType, inverseHyperbolicSineTag>::value)
         {
             // Tolerance determined by eyballing graphs in desmos
-            constexpr FloatType tolerance = 1.02;
+            constexpr auto tolerance = static_cast<FloatType> (1.02);
             if (inputGain <= tolerance)
             {
                 return static_cast<FloatType> (1.0) / inputGain;
@@ -102,7 +102,7 @@ private:
         else if constexpr (std::is_same<SaturationType, hyperbolicTangentTag>::value)
         {
             // Tolerance determined by eyballing graphs in desmos
-            constexpr FloatType tolerance = 1.02;
+            constexpr auto tolerance = static_cast<FloatType> (1.02);
             if (inputGain <= tolerance)
             {
                 return static_cast<FloatType> (1.0) / inputGain;

--- a/libs/tote_bag/dsp/Saturation.h
+++ b/libs/tote_bag/dsp/Saturation.h
@@ -65,6 +65,8 @@ public:
 
     void processBlock (juce::dsp::AudioBlock<float>& inAudio);
 
+    void clearBuffers();
+
 private:
     // tags - first step towards a templated version of this class
     struct inverseHyperbolicSineTag

--- a/libs/tote_bag/juce_gui/components/widgets/FlatTextButton.cpp
+++ b/libs/tote_bag/juce_gui/components/widgets/FlatTextButton.cpp
@@ -19,12 +19,22 @@ FlatTextButton::FlatTextButton (juce::String name)
 {
 }
 
-void FlatTextButton::paintButton (juce::Graphics& g, bool shouldDrawButtonAsHighlighted, bool shouldDrawButtonAsDown)
+void FlatTextButton::paintButton (juce::Graphics& g,
+                                  bool shouldDrawButtonAsHighlighted,
+                                  bool shouldDrawButtonAsDown)
 {
-    if (auto* lnf = dynamic_cast<LookAndFeel*> (&getLookAndFeel()))
+    if (auto* lnf = dynamic_cast<tote_bag::LookAndFeel*> (&getLookAndFeel()))
     {
-        lnf->drawFlatButtonBackground (g, *this, findColour (getToggleState() ? buttonOnColourId : buttonColourId), shouldDrawButtonAsHighlighted, shouldDrawButtonAsDown);
-        lnf->drawButtonText (g, *this, shouldDrawButtonAsHighlighted, shouldDrawButtonAsDown);
+        lnf->drawFlatButtonBackground (
+            g,
+            *this,
+            findColour (getToggleState() ? buttonOnColourId : buttonColourId),
+            shouldDrawButtonAsHighlighted,
+            shouldDrawButtonAsDown);
+        lnf->drawButtonText (g,
+                             *this,
+                             shouldDrawButtonAsHighlighted,
+                             shouldDrawButtonAsDown);
     }
     else
     {

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -352,8 +352,15 @@ void ValentineAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer,
     ffCompressor->process (highSampleRateBlock);
     saturator->processBlock (highSampleRateBlock);
 
-    if (clipOn.get())
+    const auto clip = clipOn.get();
+    if (clip)
     {
+        // Clear the buffers if clip just got turned back on
+        if (!clipOnState.get())
+        {
+            boundedSaturator->clearBuffers();
+            clipOnState.set (clip);
+        }
         boundedSaturator->processBlock (highSampleRateBlock);
     }
 

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -204,6 +204,7 @@ private:
     juce::Atomic<bool> bypassOn {false};
     juce::Atomic<bool> clipOn {
         FFCompParameterDefaults[static_cast<size_t> (VParameter::outputClip)] > 0.0f};
+    juce::Atomic<bool> clipOnState = false;
 
     juce::Atomic<bool> latencyChanged = false;
 

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -160,6 +160,8 @@ private:
 
     juce::Atomic<bool> crushOn {false};
     juce::Atomic<bool> bypassOn {false};
+    juce::Atomic<bool> clipOn {
+        FFCompParameterDefaults[static_cast<size_t> (VParameter::outputClip)] > 0.0f};
 
     // This is used for, yes you guessed it, processing
     juce::AudioBuffer<float> processBuffer;

--- a/src/ValentineParameters.h
+++ b/src/ValentineParameters.h
@@ -26,6 +26,7 @@ enum class VParameter {
     makeupGain,
     dryWet,
     bypass,
+    outputClip,
     TOTAL_NUM_PARAMETERS
 };
 
@@ -98,6 +99,7 @@ inline const std::array<juce::String, numParams>& FFCompParameterID()
         "Makeup",
         "Mix",
         "Bypass",
+        "OutputClip",
     };
 
     return parameterIDs;
@@ -115,6 +117,7 @@ inline const std::array<juce::String, numParams>& FFCompParameterLabel()
         "Output",
         "Mix",
         "Bypass",
+        "Clip",
     };
 
     return parameterLabels;
@@ -132,6 +135,7 @@ inline const std::array<juce::String, numParams>& VParameterUnit()
         " dB",
         " %",
         "",
+        "",
     };
 
     return unitLabels;
@@ -147,6 +151,7 @@ static constexpr std::array<float, numParams> FFCompParameterMin = {
     -12.0f,
     0.0f,
     0.0f,
+    0.0f,
 };
 
 static constexpr std::array<float, numParams> FFCompParameterMax = {
@@ -158,6 +163,7 @@ static constexpr std::array<float, numParams> FFCompParameterMax = {
     1100.0f,
     24.0f,
     100.0f,
+    1.0f,
     1.0f,
 };
 
@@ -171,6 +177,7 @@ static constexpr std::array<float, numParams> FFCompParameterDefaults = {
     0.0f,
     100.0f,
     0.0f,
+    1.0f,
 };
 
 static constexpr std::array<float, numParams> FFCompParameterIncrement = {
@@ -182,6 +189,7 @@ static constexpr std::array<float, numParams> FFCompParameterIncrement = {
     0.00001f,
     0.00001f,
     0.00001f,
+    1.0f,
     1.0f,
 };
 
@@ -195,6 +203,7 @@ static constexpr std::array<float, numParams> FFCompParamCenter = {
     0.0f,
     50.0f,
     0.5f,
+    0.5f,
 };
 
 static constexpr std::array<int, numParams> VParamPrecision = {
@@ -205,6 +214,7 @@ static constexpr std::array<int, numParams> VParamPrecision = {
     2,
     2,
     2,
+    0,
     0,
     0,
 };

--- a/src/ValentineParameters.h
+++ b/src/ValentineParameters.h
@@ -40,7 +40,7 @@ const size_t getParameterIndex (VParameter param)
 inline constexpr float kMinBits = 1.0f;
 inline constexpr float kMaxBits = 16.0f;
 
-inline constexpr float kMinSaturationGain = 1.0f;
+inline constexpr float kMinSaturationGain = 0.5f;
 inline constexpr float kMaxSaturationGain = 30.0f;
 
 // The largest the ratio can be as far as the parameter itself is concerned.

--- a/src/ValentineParameters.h
+++ b/src/ValentineParameters.h
@@ -23,8 +23,8 @@ enum class VParameter {
     ratio,
     attack,
     release,
-    dryWet,
     makeupGain,
+    dryWet,
     bypass,
     TOTAL_NUM_PARAMETERS
 };
@@ -95,8 +95,8 @@ inline const std::array<juce::String, numParams>& FFCompParameterID()
         "Ratio",
         "AttackTime",
         "ReleaseTime",
-        "Mix",
         "Makeup",
+        "Mix",
         "Bypass",
     };
 
@@ -112,8 +112,8 @@ inline const std::array<juce::String, numParams>& FFCompParameterLabel()
         "Ratio",
         "Attack",
         "Release",
-        "Mix",
         "Output",
+        "Mix",
         "Bypass",
     };
 
@@ -129,8 +129,8 @@ inline const std::array<juce::String, numParams>& VParameterUnit()
         "",
         " ms",
         " ms",
-        " %",
         " dB",
+        " %",
         "",
     };
 
@@ -144,8 +144,8 @@ static constexpr std::array<float, numParams> FFCompParameterMin = {
     kRatioMin,
     0.02f,
     50.0f,
-    0.0f,
     -12.0f,
+    0.0f,
     0.0f,
 };
 
@@ -156,8 +156,8 @@ static constexpr std::array<float, numParams> FFCompParameterMax = {
     kRatioParameterMax,
     10.0f,
     1100.0f,
-    100.0f,
     24.0f,
+    100.0f,
     1.0f,
 };
 
@@ -168,8 +168,8 @@ static constexpr std::array<float, numParams> FFCompParameterDefaults = {
     4.0f,
     1.3f,
     350.0f,
-    100.0f,
     0.0f,
+    100.0f,
     0.0f,
 };
 
@@ -192,8 +192,8 @@ static constexpr std::array<float, numParams> FFCompParamCenter = {
     6.0f,
     5.0f,
     300.0f,
-    50.0f,
     0.0f,
+    50.0f,
     0.5f,
 };
 
@@ -204,8 +204,8 @@ static constexpr std::array<int, numParams> VParamPrecision = {
     2,
     2,
     2,
-    0,
     2,
+    0,
     0,
 };
 

--- a/src/gui/panels/ValentineCenterPanel.cpp
+++ b/src/gui/panels/ValentineCenterPanel.cpp
@@ -37,6 +37,9 @@ CenterPanel::CenterPanel (ValentineAudioProcessor& processor)
                  processor.treeState)
     , outputSlider (FFCompParameterID()[getParameterIndex (VParameter::makeupGain)],
                     processor.treeState)
+    , outputClipButton ("Clip",
+                        FFCompParameterID()[static_cast<size_t> (VParameter::outputClip)],
+                        processor.treeState)
 {
     // Top left sliders
     addAndMakeVisible (inputSlider);
@@ -50,6 +53,7 @@ CenterPanel::CenterPanel (ValentineAudioProcessor& processor)
 
     // Top right sliders
     addAndMakeVisible (mixSlider);
+    addAndMakeVisible (outputClipButton);
     addAndMakeVisible (outputSlider);
 
     // Logo
@@ -159,6 +163,15 @@ void CenterPanel::resized()
     topRightRowBorderBounds = rightSideBounds.removeFromTop (paramWidth);
 
     auto topRightRowBounds = topRightRowBorderBounds.reduced (borderMargin);
+
+    const auto clipButtonWidth = juce::roundToInt (topRightRowBounds.getWidth() * .5f);
+    auto clipButtonBounds =
+        topRightRowBounds.removeFromBottom (juce::roundToInt (clipButtonWidth * .1f))
+            .removeFromLeft (clipButtonWidth)
+            .reduced (juce::roundToInt (clipButtonWidth * .35f), 0);
+    outputClipButton.setBounds (clipButtonBounds);
+
+    topRightRowBounds.removeFromBottom (juce::roundToInt (roundedRowMargin * .5f));
 
     std::array<LabelSlider*, numRightColumns> topRightRowComponents = {&outputSlider,
                                                                        &mixSlider};

--- a/src/gui/panels/ValentineCenterPanel.h
+++ b/src/gui/panels/ValentineCenterPanel.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "tote_bag/juce_gui/components/widgets/LabelSlider.h"
+#include "tote_bag/juce_gui/components/widgets/ParameterTextButton.h"
 #include "tote_bag/juce_gui/lookandfeel/LookAndFeelConstants.h"
 
 #include <juce_gui_basics/juce_gui_basics.h>
@@ -44,6 +45,8 @@ private:
     juce::Rectangle<int> topRightRowBorderBounds;
     LabelSlider mixSlider;
     LabelSlider outputSlider;
+
+    ParameterTextButton outputClipButton;
 
     juce::Label versionLabel;
     std::unique_ptr<juce::Drawable> vLogo;


### PR DESCRIPTION
Using Valentine on full mixes, as when processing samples,
showed that the distortion was a little too intense for subtle use cases.
Electric keys, for example, would get too edgy. 

So I decided to make the output clip optional: it's mostly there to prevent
overs when compressing wildly. This is less of a risk with already mixed material,
and it's nice to have the choice.

This desire for a little less distortion also led to the minimum for `Saturation` to be
decreased, because even at 0 it was distorting quite a bit when `Ratio` is set very low.

Another new bit: using more JUCE dsp. I wanted to get away from that, but the other 
option was implementing more dsp for non cool use cases (latency compensation). Why?