### PR TITLE
update things to fix ci

### DIFF
--- a/.github/workflows/cmake_ctest.yml
+++ b/.github/workflows/cmake_ctest.yml
@@ -52,6 +52,9 @@ jobs:
       # Thanks to McMartin & co https://forum.juce.com/t/list-of-juce-dependencies-under-linux/15121/44
       run: |
         sudo apt-get update && sudo apt install libasound2-dev libx11-dev libxinerama-dev libxext-dev libfreetype6-dev libwebkit2gtk-4.0-dev libglu1-mesa-dev xvfb fluxbox ninja-build
+        # downgrade gcc to workaround 22.04 and C++20 issue
+        # see: https://github.com/actions/runner-images/issues/8659
+        sudo apt-get install -y --allow-downgrades libc6=2.35-0ubuntu3.4 libc6-dev=2.35-0ubuntu3.4 libstdc++6=12.3.0-1ubuntu1~22.04 libgcc-s1=12.3.0-1ubuntu1~22.04
         sudo /usr/bin/Xvfb $DISPLAY &
 
     # This lets us use sscache on Windows

--- a/.github/workflows/cmake_ctest.yml
+++ b/.github/workflows/cmake_ctest.yml
@@ -54,6 +54,13 @@ jobs:
         sudo apt-get update && sudo apt install libasound2-dev libx11-dev libxinerama-dev libxext-dev libfreetype6-dev libwebkit2gtk-4.0-dev libglu1-mesa-dev xvfb fluxbox ninja-build
         sudo /usr/bin/Xvfb $DISPLAY &
 
+    # This lets us use sscache on Windows
+    # We need to install ccache here for Windows to grab the right version
+    - name: Install Ninja (Windows)
+      if: runner.os == 'Windows'
+      shell: bash
+      run: choco install ninja ccache
+
     - name: Install macOS Deps
       if: ${{ matrix.name == 'macOS' }}
       run: brew install ninja osxutils

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,7 +223,7 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
     GIT_PROGRESS TRUE
     GIT_SHALLOW TRUE
-    GIT_TAG v3.3.2)
+    GIT_TAG v3.4.0)
 FetchContent_MakeAvailable(Catch2) # find_package equivalent
 
 # Setup the test executable, again C++ 20 please


### PR DESCRIPTION
I came back from a break only to find things on fire. Nothing was building on CI.

- Windows failed because it now was missing `ninja`, for some reason.
- Linux failed because https://github.com/actions/runner-images/issues/8659
- Mac failed because I had to sign updated terms.

These changes fix the first two issues. The latter is resolved out of band.