### PR TITLE
Fix linux ci again

### DIFF
--- a/.github/workflows/cmake_ctest.yml
+++ b/.github/workflows/cmake_ctest.yml
@@ -54,7 +54,9 @@ jobs:
         sudo apt-get update && sudo apt install libasound2-dev libx11-dev libxinerama-dev libxext-dev libfreetype6-dev libwebkit2gtk-4.0-dev libglu1-mesa-dev xvfb fluxbox ninja-build
         # downgrade gcc to workaround 22.04 and C++20 issue
         # see: https://github.com/actions/runner-images/issues/8659
-        sudo apt-get install -y --allow-downgrades libc6=2.35-0ubuntu3.4 libc6-dev=2.35-0ubuntu3.4 libstdc++6=12.3.0-1ubuntu1~22.04 libgcc-s1=12.3.0-1ubuntu1~22.04
+        sudo rm -f /etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test-jammy.list
+        sudo apt-get update
+        sudo apt-get install -y --allow-downgrades libc6=2.35-0ubuntu3.5 libc6-dev=2.35-0ubuntu3.5 libstdc++6=12.3.0-1ubuntu1~22.04 libgcc-s1=12.3.0-1ubuntu1~22.04
         sudo /usr/bin/Xvfb $DISPLAY &
 
     # This lets us use sscache on Windows


### PR DESCRIPTION
The workaround for building linux introduced [here]
(https://github.com/tote-bag-labs/valentine/pull/96) broke. :(.

Bumping the libc version used in the workaround fixes the issue, 
as described [here](https://github.com/actions/runner-images/issues/8659#issuecomment-1853177960)