### PR TITLE
Fix formatting for JUCE_LIVE_CONSTANT includes

### DIFF
--- a/src/gui/panels/ValentineBottomRowPanel.cpp
+++ b/src/gui/panels/ValentineBottomRowPanel.cpp
@@ -9,7 +9,7 @@
 #include "tote_bag/juce_gui/utilities/GraphicsUtilities.h"
 
 #if JUCE_ENABLE_LIVE_CONSTANT_EDITOR
-    #include <juce_gui_extra / juce_gui_extra.h>
+    #include <juce_gui_extra/juce_gui_extra.h>
 #endif // JUCE_ENABLE_LIVE_CONSTANT_EDITOR
 
 namespace tote_bag

--- a/src/gui/panels/ValentineTopRowPanel.cpp
+++ b/src/gui/panels/ValentineTopRowPanel.cpp
@@ -9,7 +9,7 @@
 #include "tote_bag/juce_gui/utilities/GraphicsUtilities.h"
 
 #if JUCE_ENABLE_LIVE_CONSTANT_EDITOR
-    #include <juce_gui_extra / juce_gui_extra.h>
+    #include <juce_gui_extra/juce_gui_extra.h>
 #endif // JUCE_ENABLE_LIVE_CONSTANT_EDITOR
 
 namespace tote_bag


### PR DESCRIPTION
Somehow I added some spaces, making build fail if`USE_JUCE_LIVE_CONSTANT`
is set to `1` in `cmakelists.txt`.