### PR TITLE
Fix button clicks

### DIFF
--- a/src/gui/panels/ValentineBottomRowPanel.cpp
+++ b/src/gui/panels/ValentineBottomRowPanel.cpp
@@ -101,7 +101,7 @@ void BottomRowPanel::resized()
 
     // We have to do this because the slider will otherwise intercept
     // button clips.
-    const auto outputSliderWidth = sliderWidth - buttonNudge;
+    const auto outputSliderWidth = sliderWidth - juce::roundToInt (buttonNudge * 2.1f);
     const auto outputSliderX = outputSliderArea.getCentreX() - outputSliderWidth / 2;
 
     outputSlider.setBounds (

--- a/src/gui/panels/ValentineTopRowPanel.cpp
+++ b/src/gui/panels/ValentineTopRowPanel.cpp
@@ -80,7 +80,7 @@ void TopRowPanel::resized()
 
         // We have to do this because the slider will otherwise intercept
         // button clips.
-        const auto sliderWidth = sliderInitialWidth - buttonNudge;
+        const auto sliderWidth = sliderInitialWidth - buttonNudge * 2.1f;
         const auto sliderX = sliderArea.getCentreX() - sliderWidth / 2;
 
         slider.setBounds (sliderArea.withX (sliderX).withWidth (sliderWidth));

--- a/src/gui/panels/ValentineTopRowPanel.cpp
+++ b/src/gui/panels/ValentineTopRowPanel.cpp
@@ -80,7 +80,8 @@ void TopRowPanel::resized()
 
         // We have to do this because the slider will otherwise intercept
         // button clips.
-        const auto sliderWidth = sliderInitialWidth - buttonNudge * 2.1f;
+        const auto sliderWidth =
+            sliderInitialWidth - juce::roundToInt (buttonNudge * 2.1f);
         const auto sliderX = sliderArea.getCentreX() - sliderWidth / 2;
 
         slider.setBounds (sliderArea.withX (sliderX).withWidth (sliderWidth));


### PR DESCRIPTION
Making the buttons closer to the sliders caused a bug where the sliders intercepted
clicks meant for the buttons. Not great! Now you can always click the buttons.