### PR TITLE
Remove c++20 linux hack for github actions

### DIFF
--- a/.github/workflows/cmake_ctest.yml
+++ b/.github/workflows/cmake_ctest.yml
@@ -52,11 +52,6 @@ jobs:
       # Thanks to McMartin & co https://forum.juce.com/t/list-of-juce-dependencies-under-linux/15121/44
       run: |
         sudo apt-get update && sudo apt install libasound2-dev libx11-dev libxinerama-dev libxext-dev libfreetype6-dev libwebkit2gtk-4.0-dev libglu1-mesa-dev xvfb fluxbox ninja-build
-        # downgrade gcc to workaround 22.04 and C++20 issue
-        # see: https://github.com/actions/runner-images/issues/8659
-        sudo rm -f /etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test-jammy.list
-        sudo apt-get update
-        sudo apt-get install -y --allow-downgrades libc6=2.35-0ubuntu3.7 libc6-dev=2.35-0ubuntu3.7 libstdc++6=12.3.0-1ubuntu1~22.04 libgcc-s1=12.3.0-1ubuntu1~22.04
         sudo /usr/bin/Xvfb $DISPLAY &
 
     # This lets us use sscache on Windows


### PR DESCRIPTION
It looks like the underlying issue has been resolved. Hooray.