### PR TITLE
Add CLAP Support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,7 @@
 [submodule "ff_meters"]
 	path = libs/ff_meters
 	url = https://github.com/ffAudio/ff_meters.git
+[submodule "libs/clap-juce-extensions"]
+	path = libs/clap-juce-extensions
+	url = https://github.com/free-audio/clap-juce-extensions.git
+	branch = main

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ option(JUCE_ENABLE_MODULE_SOURCE_GROUPS "Show all module sources in IDE projects
 # and `git submodule update --remote --merge` to keep it up to date
 # On Github Actions, it's managed by actions/checkout
 add_subdirectory(libs/JUCE)
+add_subdirectory(libs/clap-juce-extensions EXCLUDE_FROM_ALL)
 
 # Also using Foley's Finest meters
 juce_add_module(libs/ff_meters)
@@ -77,6 +78,10 @@ juce_add_plugin("${PROJECT_NAME}"
     PLUGIN_CODE V001                            # A unique four-character plugin id with at least one upper-case character
     FORMATS "${FORMATS}"
     PRODUCT_NAME "${PROJECT_NAME}")        # The name of the final executable, which can differ from the target name
+
+clap_juce_extensions_plugin(TARGET "${PROJECT_NAME}"
+  CLAP_ID "com.ToteBagLabs.Valentine"
+  CLAP_FEATURES "audio-effect")
 
 # C++20 please
 target_compile_features("${PROJECT_NAME}" PRIVATE cxx_std_20)


### PR DESCRIPTION
Add support for the CLAP format using [clap-juce-extensions][0].

It should work on all supported OSes (Linux, Windows & macOS). I've only tested it on Linux though.

[0]: https://github.com/free-audio/clap-juce-extensions